### PR TITLE
Fix MCP notification naming to follow convention

### DIFF
--- a/docs/src/project/authentication.md
+++ b/docs/src/project/authentication.md
@@ -54,5 +54,5 @@ If permissions are too open, the server **blocks access** and informs the user o
 
 The server emits MCP notifications for auth status changes:
 
-- `onshape/auth/invalid` — Credentials became invalid
-- `onshape/auth/restored` — Credentials are valid again
+- `notifications/onshape/auth/invalid` — Credentials became invalid
+- `notifications/onshape/auth/restored` — Credentials are valid again


### PR DESCRIPTION
## Summary

- Updates MCP notification method names to follow the `notifications/<domain>/<event>` convention used by the MCP specification
- Changes `onshape/auth/invalid` → `notifications/onshape/auth/invalid`
- Changes `onshape/auth/restored` → `notifications/onshape/auth/restored`

Closes #7