### PR TITLE
Specify concrete Windows ACL requirements in docs

### DIFF
--- a/docs/src/project/authentication.md
+++ b/docs/src/project/authentication.md
@@ -35,13 +35,22 @@ secret_key = "..."
 The config file contains secrets and must have restricted permissions:
 
 - **Unix:** `0600` (owner read/write only)
-- **Windows:** File accessible only to the owner account (remove inherited permissions and grant only the owner read/write access)
+- **Windows:** File accessible only to the owner account (remove inherited permissions, clear all existing access rules, and grant only the owner read/write access)
 
-  To set Windows permissions via command line:
+  To set Windows permissions via PowerShell:
 
-  ```cmd
-  icacls "path\to\config.toml" /inheritance:r /grant:r "%USERNAME%:(R,W)"
+  ```powershell
+  $path = "path\to\config.toml"
+  $acl = Get-Acl $path
+  $acl.SetAccessRuleProtection($true, $false)
+  $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) } | Out-Null
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+      "$env:USERDOMAIN\$env:USERNAME", "Read,Write", "Allow")
+  $acl.AddAccessRule($rule)
+  Set-Acl $path $acl
   ```
+
+  To verify, run `Get-Acl "path\to\config.toml" | Format-List` and confirm only your account has access.
 
 If permissions are too open, the server **blocks access** and informs the user of the issue.
 


### PR DESCRIPTION
## Summary

- Replace vague "Equivalent ACL restrictions" with specific Windows ACL requirements
- Add `icacls` command example for setting proper file permissions
- Document that the file must be accessible only to the owner account

Closes #8