### PR TITLE
ci: add diamond emoji to pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/reflow-library.yml
 
   pre-commit:
-    name: ${{ matrix.os.emoji }} ${{ matrix.arch.emoji }} ${{ matrix.os.name }} ${{ matrix.arch.name }}
+    name: 🔶 ${{ matrix.os.emoji }} ${{ matrix.arch.emoji }} ${{ matrix.os.name }} ${{ matrix.arch.name }}
     needs: library
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
     strategy:


### PR DESCRIPTION
## Summary

- Adds 🔶 (orange diamond) emoji to the pre-commit CI job name for consistency with other jobs
- The diamond matches the [pre-commit logo](https://pre-commit.com/logo-top-shelf.png)

Closes #31