### PR TITLE
chore(deny): comment out unused license allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,15 +20,16 @@ ignore = []
 allow = [
     "MIT",
     "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "Zlib",
-    "CC0-1.0",
-    "Unicode-3.0",
-    "Unicode-DFS-2016",
-    "MPL-2.0",
+    # Pre-approved but not currently used:
+    # "Apache-2.0 WITH LLVM-exception",
+    # "BSD-2-Clause",
+    # "BSD-3-Clause",
+    # "ISC",
+    # "Zlib",
+    # "CC0-1.0",
+    # "Unicode-3.0",
+    # "Unicode-DFS-2016",
+    # "MPL-2.0",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary

- Comment out licenses that are pre-approved but not currently used by any dependencies
- Eliminates `license-not-encountered` warnings in CI
- Keeps the licenses documented for easy uncommenting when needed