### PR TITLE
fix(ci): override rust-toolchain.toml in Alpine builds

### DIFF
--- a/.github/scripts/alpine-build.sh
+++ b/.github/scripts/alpine-build.sh
@@ -18,6 +18,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # than the MSRV specified in rust-toolchain.toml
 export RUSTUP_TOOLCHAIN="$RUST_VERSION"
 
+# Verify the Rust version that will be used for compilation
+echo "=== Rust version verification ==="
+rustc --version
+echo "================================="
+
 # Setup nextest
 "$REPO_ROOT/.github/actions/setup-nextest/setup.sh"
 

--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -38,6 +38,12 @@ jobs:
           toolchain: ${{ needs.resolve-versions.outputs.stable }}
           components: rustfmt, clippy
 
+      - name: Verify Rust version
+        run: |
+          echo "=== Rust version verification ==="
+          rustc --version
+          echo "================================="
+
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -98,6 +104,13 @@ jobs:
       - name: Setup nextest
         if: matrix.os.matrix != 'linux'
         uses: ./.github/actions/setup-nextest
+
+      - name: Verify Rust version
+        if: matrix.os.matrix != 'linux'
+        run: |
+          echo "=== Rust version verification ==="
+          rustc --version
+          echo "================================="
 
       - name: Build and archive tests
         if: matrix.os.matrix != 'linux'


### PR DESCRIPTION
## Summary

- Set `RUSTUP_TOOLCHAIN` environment variable in Alpine build script to ensure the workflow-specified Rust version is used
- Prevents `rust-toolchain.toml` from redirecting cargo to use MSRV instead of the intended toolchain (stable/beta)

## Context

The Alpine CI builds were failing because cargo was respecting `rust-toolchain.toml` (which specifies MSRV 1.89) instead of using the toolchain version passed to the build script. This caused issues when testing with stable/beta toolchains.

The `actions-rust-lang/setup-rust-toolchain` action handles this automatically for non-Alpine builds via `rustup override`, but our custom Alpine scripts needed explicit toolchain pinning.