### PR TITLE
feat: update /process-comment to read full comment thread

### DIFF
--- a/.opencode/commands/process-comment.md
+++ b/.opencode/commands/process-comment.md
@@ -50,7 +50,7 @@ description: Process a GitHub PR review comment
    - Read the entire thread to understand the full context of the discussion
    - Pay special attention to the specifically linked comment—it may indicate:
      - The most recent or relevant feedback to address
-     - A specific decision or direction the user wants implemented
+     - A specific decision or direction the user wants to be implemented
      - A follow-up request after earlier discussion
    - If the thread contains back-and-forth discussion, identify the current consensus or latest request
    - Note the file path and line range from the root comment's `path`, `line`, and `start_line` fields


### PR DESCRIPTION
## Summary

- Expand the `/process-comment` command to fetch and display the entire comment thread instead of just the single linked comment
- Display thread with markdown separators and mark the specifically linked comment
- Update guidance to consider full thread context while giving special attention to the linked comment for decision-making

## Changes

- **Step 2**: Fetch all PR comments via `gh api --paginate` and build the thread using `in_reply_to_id` relationships
- **Step 2**: Display thread chronologically with markdown separators (`---`) and `<- linked comment` marker
- **Step 3**: Simplified to reference PR number already extracted in step 2
- **Step 4**: Updated to read entire thread, identify consensus from discussions, and check all comments for AI agent prompts