### PR TITLE
ci: add concurrency group to cancel redundant PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: ["**"]
   merge_group:
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: Pre-commit

--- a/docs/src/project/ci.md
+++ b/docs/src/project/ci.md
@@ -69,6 +69,18 @@ Store credentials in repository secrets:
 | `.github/workflows/reflow-npm.yml` | Reusable workflow for npm checks and coverage (1 + 5 platform jobs) |
 | `.github/workflows/update-openapi-spec.yml` | Nightly/manual OpenAPI spec update, creates PR (planned) |
 
+## Concurrency
+
+The top-level `ci.yml` workflow uses a concurrency group to cancel redundant PR runs. When a new commit is pushed to a PR, any in-progress CI run for that same PR is automatically cancelled.
+
+| Event | Group key | Behavior |
+| ----- | --------- | -------- |
+| `pull_request` | `workflow_ref` + PR number | New push cancels previous run |
+| `push` (main) | `run_id` (unique) | Runs are never cancelled |
+| `merge_group` | `run_id` (unique) | Runs are never cancelled |
+
+The concurrency group is only set on `ci.yml`. Reusable workflows (`reflow-*.yml`) inherit cancellation from the caller — when `ci.yml` is cancelled, all its called workflows are cancelled along with it.
+
 ## CI Architecture
 
 The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Each reusable workflow appears as a collapsible group containing its matrix jobs.


### PR DESCRIPTION
## Summary

- Adds a concurrency group to `ci.yml` so that pushing a new commit to a PR cancels any in-progress CI run for that same PR
- Push-to-main and merge-queue runs use a unique `run_id` group, so they are never cancelled
- Reusable workflows (`reflow-*.yml`) inherit cancellation from the caller and don't need their own concurrency groups
- Documents the concurrency strategy in `docs/src/project/ci.md`

Closes #74