### PR TITLE
Update Rust toolchain to 1.93, keep MSRV at 1.89

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89"
+channel = "1.93"
 components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary

- Update `rust-toolchain.toml` channel from `1.89` to `1.93` for local development and CI lint jobs
- MSRV remains `1.89` (unchanged in `Cargo.toml` workspace `rust-version` and CI matrix)