### PR TITLE
Add mise lock validation to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,13 @@ repos:
         pass_filenames: false
         stages: [manual]
 
+      - id: mise-lock
+        name: mise lock
+        entry: mise install --locked --dry-run
+        language: system
+        files: (^mise\.toml$|^mise\.lock$)
+        pass_filenames: false
+
       - id: sync-versions
         name: sync versions
         entry: node scripts/sync-versions.js


### PR DESCRIPTION
## Summary

- Add a `mise-lock` pre-commit hook that runs `mise install --locked --dry-run`, mirroring the CI lockfile check from `.github/workflows/reflow-mise.yml`
- Triggers only when `mise.toml` or `mise.lock` is staged, catching stale lockfiles before push