### PR TITLE
Stop grouping GitHub Actions updates into a single Renovate PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -43,12 +43,6 @@
       "groupName": "Rust toolchain"
     },
 
-    // Group GitHub Actions updates
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-
     // Override extractVersion for nextest (version_prefix workaround)
     {
       "matchDepNames": ["github:nextest-rs/nextest"],


### PR DESCRIPTION
## Summary

- Removes the `groupName: "GitHub Actions"` package rule from Renovate config so each GitHub Action dependency gets its own PR instead of being batched together.