### PR TITLE
Allow enforcing Mergify queue via required status check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 queue_rules:
   - name: default
     autoqueue: true
+    branch_protection_injection_mode: merge
     queue_conditions:
       - label = queue
       - base = main


### PR DESCRIPTION
## Summary

- Set `branch_protection_injection_mode: merge` in the Mergify queue rule so GitHub branch protection requirements are only injected into `merge_conditions`, not `queue_conditions`
- This breaks the chicken-and-egg deadlock that prevents requiring `Queue: Embarked in merge queue` as a GitHub required status check: without this setting, Mergify refuses to queue a PR because the check doesn't exist yet, but the check only gets created when the PR enters the queue

## Follow-up (after merge)

After this lands on `main`, add `Queue: Embarked in merge queue` as a required status check in the GitHub "default" ruleset (Settings > Rules > "default" > Required status checks). This will enforce that all merges to `main` go through the Mergify merge queue.