### PR TITLE
Simplify Mergify queue config: allow queueing before CI completes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,11 +3,9 @@ queue_rules:
     autoqueue: true
     branch_protection_injection_mode: merge
     queue_conditions:
-      - label = queue
+      - label = enqueue
       - base = main
-      - check-success = all
-    merge_conditions:
-      - check-success = all
+      - "#approved-reviews-by >= 1"
     merge_method: merge
     checks_timeout: 90 min
 


### PR DESCRIPTION
## Summary

- Remove `check-success` from `queue_conditions` so PRs can enter the merge queue without waiting for CI to complete
- Require at least one approval (`#approved-reviews-by >= 1`) to enter the queue
- Rename the queue label from `queue` to `enqueue`
- Remove redundant `merge_conditions` — branch protection requirements are already injected automatically via `branch_protection_injection_mode: merge`