### PR TITLE
Add knowledge pipeline design docs and knowledge base skeleton

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,22 @@
 - [npm Wrapper](project/npm-wrapper.md)
 - [OAuth Proxy](project/oauth-proxy.md)
 
+# Knowledge Pipeline
+
+- [Overview](project/knowledge-pipeline/index.md)
+  - [Architecture](project/knowledge-pipeline/architecture.md)
+  - [Methodology](project/knowledge-pipeline/methodology.md)
+  - [Reference Models](project/knowledge-pipeline/reference-models.md)
+  - [Open Questions](project/knowledge-pipeline/open-questions.md)
+
+# Knowledge Base
+
+- [Overview](knowledge/index.md)
+  - [Generic CAD Concepts](knowledge/generic-cad/index.md)
+  - [Onshape Domain Model](knowledge/onshape-domain/index.md)
+  - [API Mechanics](knowledge/api-mechanics/index.md)
+  - [Workflow Patterns](knowledge/workflow-patterns/index.md)
+
 # Insights
 
 - [Shaded Views](mcp-resources/insights/shaded-views.md)

--- a/docs/src/knowledge/api-mechanics/index.md
+++ b/docs/src/knowledge/api-mechanics/index.md
@@ -1,0 +1,5 @@
+# API Mechanics
+
+Onshape REST API specifics: endpoint patterns, payload structures, ID resolution, transient ID queries, error handling.
+
+This layer is populated by the [knowledge pipeline](../../project/knowledge-pipeline/index.md).

--- a/docs/src/knowledge/generic-cad/index.md
+++ b/docs/src/knowledge/generic-cad/index.md
@@ -1,0 +1,6 @@
+# Generic CAD Concepts
+
+Foundational CAD concepts portable across CAD systems.
+Covers topology, sketch constraints, feature operations, assembly concepts, coordinate systems, and boolean operations.
+
+This layer is populated by the [knowledge pipeline](../../project/knowledge-pipeline/index.md).

--- a/docs/src/knowledge/index.md
+++ b/docs/src/knowledge/index.md
@@ -1,0 +1,13 @@
+# Knowledge Base
+
+Layered source knowledge produced by the [knowledge pipeline](../project/knowledge-pipeline/index.md).
+
+Content in this directory is the canonical representation of Onshape API knowledge, organized for maintainability and clear reasoning.
+It is [compiled](../project/knowledge-pipeline/architecture.md#compilation) into integrated LLM-optimized resources for runtime consumption.
+
+## Layers
+
+- [Generic CAD Concepts](generic-cad/index.md) — Portable CAD foundations
+- [Onshape Domain Model](onshape-domain/index.md) — Onshape-specific concept mapping
+- [API Mechanics](api-mechanics/index.md) — REST API specifics
+- [Workflow Patterns](workflow-patterns/index.md) — Idiomatic operation sequences

--- a/docs/src/knowledge/onshape-domain/index.md
+++ b/docs/src/knowledge/onshape-domain/index.md
@@ -1,0 +1,6 @@
+# Onshape Domain Model
+
+How Onshape implements generic CAD concepts.
+Covers part studios, assemblies, feature tree semantics, the BTType system, configurations, contexts, and the document/workspace/version/element model.
+
+This layer is populated by the [knowledge pipeline](../../project/knowledge-pipeline/index.md).

--- a/docs/src/knowledge/workflow-patterns/index.md
+++ b/docs/src/knowledge/workflow-patterns/index.md
@@ -1,0 +1,6 @@
+# Workflow Patterns
+
+Idiomatic operation sequences for common CAD tasks via the Onshape API.
+References [generic CAD concepts](../generic-cad/index.md), [Onshape domain model](../onshape-domain/index.md), and [API mechanics](../api-mechanics/index.md).
+
+This layer is populated by the [knowledge pipeline](../../project/knowledge-pipeline/index.md).

--- a/docs/src/project/index.md
+++ b/docs/src/project/index.md
@@ -26,6 +26,11 @@ A Rust-based MCP (Model Context Protocol) server for Onshape integration. The pr
 - [npm Wrapper](npm-wrapper.md) — npm package design for `npx` installation
 - [OAuth Proxy](oauth-proxy.md) — Cloudflare Worker token exchange proxy for OAuth2
 
+### Knowledge Pipeline
+
+- [Knowledge Pipeline](knowledge-pipeline/index.md) — Self-supervised methodology for building CAD API knowledge
+- [Knowledge Base](../knowledge/index.md) — Layered source knowledge produced by the pipeline
+
 ### Project Management
 
 - [Implementation](implementation.md) — Phase checklist, roadmap

--- a/docs/src/project/knowledge-pipeline/architecture.md
+++ b/docs/src/project/knowledge-pipeline/architecture.md
@@ -1,0 +1,96 @@
+# Knowledge Pipeline Architecture
+
+## Overview
+
+Knowledge is maintained in four source layers, each building on the previous.
+The source layers are optimized for maintainability and clear reasoning.
+A separate compilation step produces integrated, token-efficient resources for LLM consumption.
+
+```text
+                        ┌───────────────────────────┐
+                        │     Reference Models       │
+                        │    (Onshape documents)     │
+                        └─────────────┬─────────────┘
+                                      │
+                        ┌─────────────▼─────────────┐
+                        │   Self-Supervised Loop     │
+                        │   (analyze, attempt,       │
+                        │    review, learn)          │
+                        └─────────────┬─────────────┘
+                                      │
+           ┌──────────────────────────▼──────────────────────────┐
+           │            Layered Source Knowledge                  │
+           │                                                     │
+           │   L1: Generic CAD Concepts                          │
+           │   L2: Onshape Domain Model                          │
+           │   L3: API Mechanics                                 │
+           │   L4: Workflow Patterns                              │
+           └──────────────────────────┬──────────────────────────┘
+                                      │
+                        ┌─────────────▼─────────────┐
+                        │     Compilation            │
+                        │     (manual trigger)       │
+                        └─────────────┬─────────────┘
+                                      │
+           ┌──────────────────────────▼──────────────────────────┐
+           │       Compiled Insight Resources                     │
+           │       (task-oriented, LLM-optimized)                │
+           └─────────────────────────────────────────────────────┘
+
+           ┌─────────────────────────────────────────────────────┐
+           │       Manual Insight Resources                       │
+           │       (existing: sketch, extrude, shaded views)     │
+           │       (independent of pipeline)                     │
+           └─────────────────────────────────────────────────────┘
+```
+
+## Knowledge Layers
+
+### Layer 1: Generic CAD Concepts
+
+Foundational CAD knowledge portable across CAD systems: topology (faces, edges, vertices), sketch constraint systems, feature operations (extrude, revolve, sweep, loft, fillet, chamfer, pattern, mirror, boolean, shell, draft), assembly mating concepts, coordinate systems.
+
+This layer is aspirationally shareable with other CAD API integration projects but is not over-engineered for reuse.
+Clean separation of concerns within this project is the primary goal.
+
+**Location:** [`docs/src/knowledge/generic-cad/`](../../knowledge/generic-cad/index.md)
+
+### Layer 2: Onshape Domain Model
+
+How Onshape implements generic CAD concepts.
+Part studios vs. assemblies vs. drawings, feature tree semantics, the BTType system, configurations, contexts, the document/workspace/version/element model, element types, reference geometry.
+
+This layer bridges from generic CAD understanding to Onshape-specific abstractions.
+
+**Location:** [`docs/src/knowledge/onshape-domain/`](../../knowledge/onshape-domain/index.md)
+
+### Layer 3: API Mechanics
+
+Onshape REST API specifics: endpoint signatures, payload structures, ID resolution patterns (document/workspace/element IDs, transient IDs, deterministic IDs), authentication, error handling, query parameter conventions.
+
+Partially derivable from the OpenAPI spec, but the spec alone does not capture the domain knowledge needed to use endpoints correctly.
+
+**Location:** [`docs/src/knowledge/api-mechanics/`](../../knowledge/api-mechanics/index.md)
+
+### Layer 4: Workflow Patterns
+
+Idiomatic sequences for common tasks.
+Each pattern references concepts from all three layers above: what CAD operation is being performed (L1), how Onshape models it (L2), and what API calls implement it (L3).
+
+Examples: "to fillet an edge, create a fillet feature referencing edge transient IDs obtained from a topology query", "to create a sketch on a face, use a mate connector subFeature targeting the face".
+
+Encodes ordering constraints, common compositions, and error recovery strategies.
+
+**Location:** [`docs/src/knowledge/workflow-patterns/`](../../knowledge/workflow-patterns/index.md)
+
+## Compilation
+
+The layered source knowledge is the canonical representation — optimized for maintainability, auditability, and clear reasoning about why things are done a certain way.
+
+A compilation step produces integrated, per-topic resources optimized for LLM context windows: flattened, cross-referenced, redundancy removed.
+This is analogous to how compiled code works — you keep the source hierarchy for development but ship a different form for execution.
+
+Compilation is triggered manually.
+The compiled output is a build artifact that can be regenerated from the source layers.
+
+The compilation mechanism, output format, and serving strategy are [open questions](open-questions.md#pipeline-mechanics).

--- a/docs/src/project/knowledge-pipeline/index.md
+++ b/docs/src/project/knowledge-pipeline/index.md
@@ -1,0 +1,26 @@
+# Knowledge Pipeline
+
+A self-supervised methodology for building layered CAD API knowledge that can be compiled into LLM-optimized reference material.
+
+## Motivation
+
+The Onshape API is large and domain-specific.
+An LLM cannot reliably use it from endpoint signatures alone — it needs contextual knowledge about CAD concepts, Onshape's data model, payload structures, and idiomatic operation sequences.
+This pipeline systematically builds that knowledge through a loop of expert demonstration, automated analysis, and iterative refinement.
+
+## Relationship to Manual Insights
+
+The existing [Insights](../../mcp-resources/insights/index.md) resources (sketch, extrude, shaded views) were authored manually and remain independent of this pipeline.
+The pipeline produces its own compiled output.
+Whether compiled output eventually supplements or replaces manual insights is an [open question](open-questions.md#knowledge-organization).
+
+## Documentation
+
+- [Architecture](architecture.md) — Knowledge layer model, compilation, artifact locations
+- [Methodology](methodology.md) — The self-supervised learning loop, roles, step-by-step process
+- [Reference Models](reference-models.md) — Identification scheme, metadata conventions, curriculum design
+- [Open Questions](open-questions.md) — Unresolved design decisions
+
+## Knowledge Base
+
+The pipeline populates the [Knowledge Base](../../knowledge/index.md), a layered collection of source material organized for maintainability and clear reasoning.

--- a/docs/src/project/knowledge-pipeline/methodology.md
+++ b/docs/src/project/knowledge-pipeline/methodology.md
@@ -1,0 +1,116 @@
+# Knowledge Pipeline Methodology
+
+## Overview
+
+Knowledge is built through a self-supervised loop: Claude generates reference tasks, a human models them in Onshape, Claude analyzes the results and attempts to recreate them via API, and failures drive knowledge updates.
+
+The human is the expert in the loop — performing CAD modeling, reviewing recreation quality, and resolving questions that Claude cannot answer from the API alone.
+Claude handles task generation, API interaction, analysis, and documentation.
+
+## The Learning Loop
+
+| Step | Actor | Action |
+| --- | --- | --- |
+| 1. Design | Claude | Generate reference task spec |
+| 2. Create | Claude | Create Onshape document with metadata |
+| 3. Model | Human | Build the part in the Onshape UI |
+| 4. Signal | Human | Provide document URL or UUID in chat |
+| 5. Analyze | Claude | Read feature tree and version history |
+| 6. Attempt | Claude | Recreate in a separate throwaway document |
+| 7. Review | Human | Evaluate quality of recreation attempt |
+| 8. Learn | Claude | Diagnose failures, extract insights |
+| 9. Document | Claude | Update knowledge layers and document notes |
+| 10. Compile | Human-triggered | Produce compiled insight resources |
+
+### Step 1: Design
+
+Claude generates a reference task specification targeting specific CAD operations and complexity tiers defined in the [curriculum](reference-models.md#curriculum-design).
+
+The task spec includes: what to model, which CAD concepts it exercises, expected complexity, and what knowledge gaps it is designed to probe.
+
+Task batches are informed by failures from previous iterations — operations that Claude struggled with get prioritized in subsequent batches.
+
+### Step 2: Create
+
+Claude creates an Onshape document via the `createDocument` API endpoint and populates metadata fields per the [metadata schema](reference-models.md#metadata-schema).
+
+The document description contains the machine-parseable task spec.
+The workspace description is set to `awaiting modeling`.
+
+### Step 3: Model
+
+The human builds the part in the Onshape UI.
+No special tooling or workflow changes required — standard Onshape modeling.
+
+The feature tree and version history capture the process automatically, including the sequence of operations and any iterations or corrections the modeler makes.
+
+### Step 4: Signal
+
+The human provides the document URL or reference model UUID to Claude in conversation.
+No metadata update required — Claude reads the current state directly.
+
+### Step 5: Analyze
+
+Claude reads the reference model through the MCP server:
+
+- Feature tree via `getPartStudioFeatures`
+- Version history via `getDocumentHistory`
+- Element metadata via `getElementsInDocument`
+
+Claude maps each feature to its understanding of the corresponding API calls, noting any unknowns or uncertainties.
+
+### Step 6: Attempt
+
+Claude creates a separate throwaway Onshape document and attempts to recreate the reference model via API calls through the MCP server.
+
+A separate document is used to avoid polluting the reference model.
+The throwaway document can be deleted after review.
+
+### Step 7: Review
+
+The human evaluates the recreation attempt for quality.
+
+This is currently a manual process — the human compares the recreation against the reference model and communicates results to Claude in conversation.
+
+Automating portions of this review is an [open question](open-questions.md#pipeline-mechanics).
+
+### Step 8: Learn
+
+Claude diagnoses differences between the reference and the attempt.
+Failures are the primary learning signal — they reveal exactly where the knowledge base is insufficient.
+
+Failure categories include:
+
+- **Wrong API call** — Used the wrong endpoint or operation
+- **Wrong payload** — Correct endpoint but incorrect BTType, parameter, or structure
+- **Wrong sequence** — Correct operations in the wrong order
+- **Missing prerequisite** — Did not know an intermediate step was required (e.g., querying transient IDs before referencing geometry)
+- **Conceptual gap** — Misunderstood how Onshape models a particular CAD concept
+
+Each failure maps to one or more knowledge layers that need updating.
+
+### Step 9: Document
+
+Claude updates the relevant knowledge layer files in `docs/src/knowledge/` based on what was learned.
+
+Claude also writes analysis notes to the reference model's Onshape document:
+
+- **Document notes** — Human-readable narrative of what was learned
+- **Comments** — Per-feature annotations where relevant
+- **Workspace description** — Updated to reflect pipeline status
+
+### Step 10: Compile
+
+Triggered manually by the human (in conversation, via script, or other mechanism).
+
+Updated knowledge layers are compiled into integrated, LLM-optimized resources.
+The compilation mechanism is an [open question](open-questions.md#pipeline-mechanics).
+
+## Feedback Dynamics
+
+The loop is self-correcting: if compiled knowledge leads Claude to make incorrect API calls in future iterations, those failures surface in step 7 and feed back into knowledge updates.
+
+Claude's task designs (step 1) are also informed by the loop — by articulating assumptions about how CAD operations work, Claude exposes those assumptions to testing.
+When assumptions are wrong for Onshape specifically, that is exactly the knowledge gap the pipeline needs to fill.
+
+The human's role diminishes over time as the knowledge base matures, shifting from frequent review and correction to occasional validation and edge-case resolution.

--- a/docs/src/project/knowledge-pipeline/open-questions.md
+++ b/docs/src/project/knowledge-pipeline/open-questions.md
@@ -1,0 +1,27 @@
+# Knowledge Pipeline Open Questions
+
+## Pipeline Mechanics
+
+- [ ] Recreation location — Currently planning separate throwaway documents for recreation attempts.
+  Alternatives: same document with a new Part Studio tab, or a dedicated recreation workspace.
+- [ ] Comparison automation — Currently human review for quality assessment.
+  Future: automated geometric comparison, feature tree diffing, or hybrid approaches.
+- [ ] Compilation mechanism — Manual trigger, specifics to be determined.
+  Options: AI-driven in conversation, scripted tooling, hybrid.
+- [ ] Compiled output location — Where do compiled insight resources live on disk?
+  How do they integrate with the existing MCP resource serving mechanism (compile-time codegen from `docs/src/mcp-resources/`)?
+
+## Knowledge Organization
+
+- [ ] Manual vs. compiled insight coexistence — How do hand-written insights and pipeline-generated insights share the `mcp-resources/` space?
+  Options: separate resource groups (e.g., `insights-generated:`), unified with provenance tags, compiled replaces manual over time.
+- [ ] Contribution model — How other people's Onshape models enter the pipeline.
+  Needs: discovery mechanism, quality criteria, metadata conventions for external contributions.
+- [ ] Layer 1 portability — Whether generic CAD concepts are shared with other projects or only cleanly separated within this one.
+- [ ] Document description format — Exact structured format for the machine-parseable task spec in the document description field.
+  Must be both machine-parseable and reasonably human-readable in the Onshape UI.
+
+## Onshape API Limitations
+
+- [ ] Tags — The Onshape API silently drops tags on document creation/update.
+  Need alternative categorization approach if tags are required for filtering or enumeration.

--- a/docs/src/project/knowledge-pipeline/reference-models.md
+++ b/docs/src/project/knowledge-pipeline/reference-models.md
@@ -1,0 +1,90 @@
+# Reference Models
+
+Reference models are Onshape documents that serve as ground truth for the [learning loop](methodology.md#the-learning-loop).
+Each document is simultaneously a CAD model, a test case specification, and a learning log.
+
+## Identification
+
+Each reference model has two identifiers:
+
+- **UUID** — Stable, universally unique.
+  Stored in Onshape document metadata.
+  Used for cross-referencing in the knowledge base.
+  Never changes, even if the model is reorganized.
+- **Hierarchy path** — Human-navigable structure that conveys intent and categorization at a glance.
+  Can be reorganized without breaking UUID-based references.
+
+Example: hierarchy path `ref/sketch/constraints/coincident` with UUID `a1b2c3d4-e5f6-7890-abcd-ef1234567890`.
+
+The hierarchy provides browsable structure without imposing an artificial scale limit.
+Depth and branching grow organically with the curriculum.
+
+## Metadata Schema
+
+Reference models use Onshape document metadata fields to store pipeline state and analysis results.
+All fields are both visible in the Onshape UI and programmatically accessible via the API.
+
+| Field | Onshape location | API | Purpose |
+| --- | --- | --- | --- |
+| Document name | Document properties | `updateDocumentAttributes` | Human-readable title including hierarchy path |
+| Document description | Document details (10K chars) | `updateDocumentAttributes` | Machine-parseable task spec |
+| Document notes | Left sidebar panel | `updateDocumentAttributes` | Human-readable analysis narrative |
+| Workspace description | Workspace properties | `updateWVMetadata` | Pipeline status |
+| Comments | Left sidebar comments | `createComment` | Per-feature annotations from analysis |
+
+### Pipeline Status Values
+
+The workspace description field tracks where a reference model is in the learning loop:
+
+| Status | Meaning |
+| --- | --- |
+| `awaiting modeling` | Document created, task spec written, waiting for human to model |
+| `modeled` | Human has completed the model |
+| `analyzed` | Claude has read and analyzed the feature tree |
+| `attempted` | Claude has attempted API recreation |
+| `reviewed` | Human has reviewed the recreation attempt |
+| `documented` | Knowledge layers have been updated from this reference |
+
+### Document Description Format
+
+The document description field contains a machine-parseable task specification.
+The exact structured format is an [open question](open-questions.md#knowledge-organization) — it must be both machine-parseable and reasonably human-readable in the Onshape UI.
+
+Required fields:
+
+- UUID
+- Hierarchy path
+- Target CAD operations
+- Complexity tier
+- Coverage tags
+- Original task prompt from Claude
+
+## Curriculum Design
+
+### Complexity Tiers
+
+Reference models are organized by complexity to ensure foundational knowledge is established before tackling advanced patterns.
+
+**Tier 1: Primitives** — Individual operations in isolation.
+Sketch types, extrude, revolve, sweep, loft, fillet, chamfer, pattern, mirror, boolean, shell, draft.
+Establishes the basic API call for each operation.
+
+**Tier 2: Combinations** — Operations that interact.
+Fillet after pattern vs. pattern after fillet, sketches referencing other features, multi-body workflows.
+Reveals ordering dependencies and reference resolution patterns.
+
+**Tier 3: Assemblies** — Multi-part compositions.
+Fixed + one mate, multi-part constrained, sub-assemblies, configurations.
+Introduces assembly-specific API patterns and cross-part references.
+
+**Tier 4: Edge cases** — Patterns that tend to trip up API usage.
+Reference geometry, derived features, in-context editing, configurations with suppression, import/export.
+Surfaces Onshape-specific behaviors that diverge from generic CAD assumptions.
+
+### Coverage Tracking
+
+Each reference model maps to specific knowledge layer content it informs.
+This mapping is recorded in the document metadata and in the knowledge layer files themselves.
+
+Gaps are identified by comparing the curriculum's target coverage against the knowledge base's actual content.
+Claude designs subsequent task batches to target identified gaps, with priority given to operations that caused failures in previous iterations.


### PR DESCRIPTION
## Summary

- Add design documentation for the self-supervised knowledge pipeline methodology under `docs/src/project/knowledge-pipeline/` (architecture, methodology, reference models, open questions)
- Add empty knowledge base directory structure under `docs/src/knowledge/` with placeholder index files for each of the four layers (generic-cad, onshape-domain, api-mechanics, workflow-patterns)
- Update SUMMARY.md and project index with new sections

## Context

Documents the pipeline for systematically building Onshape API knowledge: Claude generates reference CAD tasks, a human models them in Onshape, Claude analyzes feature trees and attempts API recreation, and failures drive knowledge base updates. The layered source knowledge is then compiled into LLM-optimized resources.

This is design documentation only — no code changes. The knowledge base directories are empty placeholders ready to be populated as the pipeline runs.