### PR TITLE
fix(ci): use !cancelled() for checks job to prevent merge queue dequeuing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   checks:
     name: checks
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [mise, pre-commit, rust, coverage, npm]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Change the `checks` job condition from `if: always()` to `if: ${{ !cancelled() }}` to match the `all` job

## Problem

PRs (e.g. #226, #224) keep getting dequeued from the Mergify merge queue. The sequence:

1. PR enters the merge queue
2. Mergify re-runs the CI workflow (`triggering_actor: mergify[bot]`), creating a new attempt
3. The re-run cancels the current attempt
4. The `checks` job runs anyway (`if: always()`), sees cancelled dependencies, and `alls-green` reports **FAILURE**
5. Mergify sees this terminal failure and concludes "merge conditions cannot be satisfied" → dequeues
6. The new attempt eventually succeeds, but the PR is already dequeued

## Fix

Change `checks` to `if: ${{ !cancelled() }}` (matching the `all` job). This way:

- When a workflow is cancelled by a re-run, `checks` does **not** run, so no false FAILURE is reported
- Mergify sees only cancelled (non-terminal) checks and waits for the new attempt to complete
- When dependencies genuinely **fail**, `checks` still runs and reports the failure (since `!cancelled()` is true when deps fail)