### PR TITLE
Disable attestation verification and increase HTTP timeout in mise settings

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,11 @@
+[settings]
+# Disable GitHub attestation verification and increase HTTP timeout to eliminate
+# flaky CI failures (especially on Windows runners). mise.lock already pins
+# SHA256 checksums for integrity. This also affects local dev — a trade-off for
+# simplicity over CI-only env vars. See #247.
+github_attestations = false
+http_timeout = "120s"
+
 [tools]
 node = "24"
 python = "3"


### PR DESCRIPTION
## Summary

- Adds `[settings]` to `mise.toml` with `github_attestations = false` and `http_timeout = "120s"` to eliminate the most common category of flaky CI failures — transient GitHub attestation/SLSA verification HTTP errors and download timeouts, especially on Windows runners.
- `mise.lock` already pins SHA256 checksums for every platform, so attestation is defense-in-depth. Applying these settings globally (rather than as CI-only env vars on each workflow step) is a trade-off for simplicity.

Closes #247