### PR TITLE
Revoke old access tokens when issuing new ones via refresh or re-auth

### DIFF
--- a/crates/onshape-mcp-io/src/oauth_server.rs
+++ b/crates/onshape-mcp-io/src/oauth_server.rs
@@ -1891,6 +1891,7 @@ mod tests {
         );
 
         // Perform the refresh grant.
+        let expected_client_id = client_id.clone();
         let req = TokenRequest {
             grant_type: "refresh_token".to_string(),
             code: None,
@@ -1917,7 +1918,7 @@ mod tests {
                 .read()
                 .await
                 .values()
-                .filter(|t| t.user_id == "allowed-user-1")
+                .filter(|t| t.user_id == "allowed-user-1" && t.client_id == expected_client_id)
                 .count(),
             1,
             "exactly one access token should exist after refresh"


### PR DESCRIPTION
## Summary

- Adds a `replace_token()` helper that removes any existing tokens for the same `(user_id, client_id)` pair before inserting a new one
- Updates both `handle_auth_code_grant()` and `handle_refresh_token_grant()` to use `replace_token()` instead of direct `.insert()`, ensuring at most one access token and one refresh token exist per user+client pair
- Adds two tests verifying old tokens are revoked on refresh and on re-authentication

## Context

When a client used `grant_type=refresh_token`, the old refresh token was correctly consumed (single-use rotation), but the old access token remained valid in the `tokens` map until its natural 1-hour expiry. Similarly, re-authenticating from scratch left old tokens as orphans. This was a defense-in-depth gap identified during auth security audit.

Uses Option 2 from the issue: per-client single-token enforcement via `retain()`, which also handles the re-auth case without requiring any structural changes.

Closes #254