### PR TITLE
fix: use semicolon separator for Renovate docker-volumes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,9 +25,7 @@ jobs:
       - uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          docker-volumes: |
-            /tmp:/tmp
-            /home/runner/.local/bin/mise:/usr/local/bin/mise
+          docker-volumes: /tmp:/tmp;/home/runner/.local/bin/mise:/usr/local/bin/mise
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '["^mise lock "]'


### PR DESCRIPTION
## Summary

- Fix Renovate workflow failing since 2026-03-14 (`5d302e2`) due to `docker-volumes` using newline separators instead of semicolons
- The `renovatebot/github-action` [splits by `;`](https://github.com/renovatebot/github-action/blob/main/src/input.ts#L79), so the YAML block scalar (`|`) produced a single combined string that Docker parsed as one `--volume` argument, failing with `invalid mode: /usr/local/bin/mise`

Closes the breakage visible in https://github.com/altendky/onshape-mcp/actions/runs/23143153328