### PR TITLE
feat: add debug logging option to Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      debug:
+        description: "Enable debug logging"
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -37,3 +43,4 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '["^mise lock --yes -- [A-Za-z0-9_./:-]+$"]'
+          LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}


### PR DESCRIPTION
## Summary

Add a `debug` input to the Renovate workflow that enables debug-level logging when triggered manually.

This will help troubleshoot why `postUpgradeTasks` (specifically `mise lock`) isn't running for mise-managed dependencies.

## Usage

```bash
gh workflow run renovate.yml -f debug=true
```

## Context

- PR #286 was created without `mise.lock` updates despite the `postUpgradeTasks` config
- The INFO-level logs don't show why `postUpgradeTasks` isn't executing
- Debug logs should reveal whether the config is matching and what's happening