### PR TITLE
fix: add post-Renovate step to update mise.lock

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,3 +44,49 @@ jobs:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '["^mise lock --yes -- [A-Za-z0-9_./:-]+$"]'
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}
+
+      # Post-Renovate: update mise.lock on branches where postUpgradeTasks
+      # couldn't run (e.g., npm:* packages need npm which isn't in the container)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Update mise.lock on Renovate branches
+        run: |
+          set -euo pipefail
+
+          # Configure git for commits
+          git config user.name "altendky-renovate[bot]"
+          git config user.email "189994954+altendky-renovate[bot]@users.noreply.github.com"
+
+          # Find renovate branches with mise.toml changes where mise.lock is stale
+          for branch in $(git branch -r --list 'origin/renovate/*' | sed 's|origin/||'); do
+            # Check if this branch has mise.toml changes vs main
+            if ! git diff --quiet "origin/main..origin/$branch" -- mise.toml 2>/dev/null; then
+              echo "::group::Processing $branch"
+              git checkout "$branch"
+              git reset --hard "origin/$branch"
+
+              # Install runtimes needed for mise lock to query package registries
+              # - node: for npm:* packages (npm needed to query npmjs.org)
+              # - python: for pipx:* packages (pip needed to query PyPI)
+              mise install --yes node python || true
+
+              # Run mise lock to update the lockfile
+              if mise lock --yes; then
+                # Check if mise.lock changed
+                if ! git diff --quiet -- mise.lock; then
+                  git add mise.lock
+                  git commit -m "chore: update mise.lock"
+                  git push
+                  echo "Updated mise.lock on $branch"
+                else
+                  echo "mise.lock already up to date on $branch"
+                fi
+              else
+                echo "::warning::mise lock failed on $branch"
+              fi
+              echo "::endgroup::"
+            fi
+          done


### PR DESCRIPTION
## Summary

The Renovate `postUpgradeTasks` runs inside the Renovate Docker container where npm is not available. This causes `mise lock` to fail for `npm:*` packages like `npm:wrangler`:

```
mise WARN  npm may be required but was not found.
mise WARN  Failed to resolve tool version list for npm:wrangler
```

This PR adds a post-step that runs on the GitHub Actions runner (where mise can install npm via the configured node version) to update `mise.lock` on any renovate branches that have stale lockfiles.

## How it works

1. Renovate runs in Docker, creates/updates branches
2. After Renovate finishes, the new step:
   - Lists all `renovate/*` branches with `mise.toml` changes
   - Checks out each branch
   - Installs node (for npm access)
   - Runs `mise lock --yes`
   - If mise.lock changed, commits and pushes

## Testing

Manually tested the approach on PR #293 (`npm:wrangler`) - successfully updated `mise.lock` after running the commands outside Docker.