### PR TITLE
fix: add permissive RENOVATE_ALLOWED_COMMANDS

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,4 +42,5 @@ jobs:
           docker-volumes: /tmp:/tmp;${{ steps.mise-path.outputs.bin }}:/usr/local/bin/mise
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          RENOVATE_ALLOWED_COMMANDS: '[".*"]'
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}


### PR DESCRIPTION
## Summary

Renovate requires `RENOVATE_ALLOWED_COMMANDS` to be set for `postUpgradeTasks` to run. Without it, commands are silently skipped:

```
WARN: Post-upgrade task did not match any on allowedCommands list
"allowedCommands": []
```

This was causing the `mise run --yes lock-tool {{{depName}}}` command to be skipped, so `mise.lock` was never updated.

## Changes

Add `RENOVATE_ALLOWED_COMMANDS: '[".*"]'` to allow any command. Since both `renovate.json5` and the workflow file require the same review process to modify, the allowlist provides no additional security benefit.