### PR TITLE
fix: add --no-prepare to skip installing all mise tools

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -56,7 +56,7 @@
       "matchManagers": ["mise"],
       "postUpgradeTasks": {
         "commands": [
-          "mise run --yes lock-tool {{{depName}}}"
+          "mise run --yes --no-prepare lock-tool {{{depName}}}"
         ],
         "fileFilters": ["mise.lock"],
         "executionMode": "update"


### PR DESCRIPTION
## Summary

`mise run` normally installs all tools from `mise.toml` before running a task. In the Renovate Docker container, this fails because `pipx` isn't available to install `pipx:pre-commit`:

```
mise ERROR Failed to install pipx:pre-commit@4.5.1: failed to execute command: pipx install pre-commit==4.5.1: No such file or directory (os error 2)
```

## Fix

Add `--no-prepare` to skip the auto-install. The `lock-tool` task explicitly installs only `node` and `python`, which is all it needs for the lock command.