### PR TITLE
fix: use direct mise commands instead of task

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -49,14 +49,17 @@
     },
 
     // After bumping a mise tool version, re-lock that tool for all platforms
-    // so mise.lock stays in sync. See mise.toml [tasks.lock-tool] for details.
+    // so mise.lock stays in sync. Uses direct commands instead of a mise task
+    // to avoid mise trying to install all tools from mise.toml (which fails
+    // for pipx:pre-commit since pipx isn't available in the Docker container).
     // Requires mise binary mounted into the Renovate container — see
     // .github/workflows/renovate.yml.
     {
       "matchManagers": ["mise"],
       "postUpgradeTasks": {
         "commands": [
-          "mise run --yes --no-prepare lock-tool {{{depName}}}"
+          "mise install --yes node python",
+          "mise lock --yes --platform linux-x64,linux-x64-musl,linux-arm64,linux-arm64-musl,macos-x64,macos-arm64,windows-x64 -- {{{depName}}}"
         ],
         "fileFilters": ["mise.lock"],
         "executionMode": "update"


### PR DESCRIPTION
## Summary

`mise run` activates the full mise environment, which tries to install ALL tools from `mise.toml` (including `pipx:pre-commit` which fails because pipx isn't available in the Docker container).

Using direct `mise install`/`mise lock` commands bypasses this environment activation and only installs the specific tools we need (node, python).

## Changes

Replace:
```
mise run --yes --no-prepare lock-tool {{{depName}}}
```

With:
```
mise install --yes node python
mise lock --yes --platform ... -- {{{depName}}}
```