### PR TITLE
fix: enable locked mode to avoid GitHub API calls during install

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@
 # simplicity over CI-only env vars. See #247.
 github_attestations = false
 http_timeout = "120s"
+locked = true
 
 [tools]
 node = "24"


### PR DESCRIPTION
## Summary

`mise install` was failing on Windows CI runners because the aqua backend
queries `api.github.com` to resolve release URLs, hitting TLS handshake errors:

```
Failed to install aqua:EmbarkStudios/cargo-deny@0.19.0: error sending request
for url (https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/tags/0.19.0):
client error (Connect): unexpected EOF during handshake
```

## Fix

Set `locked = true` in `mise.toml` settings. This makes mise use pre-resolved
URLs from `mise.lock` directly, eliminating GitHub API calls during installation.

Same philosophy as the existing `github_attestations = false` setting — a
global trade-off for simplicity over CI-only env vars.