### PR TITLE
fix(renovate): disable locked mode for mise postUpgradeTasks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -54,12 +54,17 @@
     // for pipx:pre-commit since pipx isn't available in the Docker container).
     // Requires mise binary mounted into the Renovate container — see
     // .github/workflows/renovate.yml.
+    //
+    // MISE_LOCKED=0 is required because mise.toml has `locked = true`, which
+    // prevents `mise lock` from running. The `sh -c` wrapper is needed because
+    // Renovate doesn't execute commands through a shell that interprets
+    // `VAR=value command` syntax.
     {
       "matchManagers": ["mise"],
       "postUpgradeTasks": {
         "commands": [
-          "mise install --yes node python",
-          "mise lock --yes --platform linux-x64,linux-x64-musl,linux-arm64,linux-arm64-musl,macos-x64,macos-arm64,windows-x64 -- {{{depName}}}"
+          "sh -c 'MISE_LOCKED=0 mise install --yes node python'",
+          "sh -c 'MISE_LOCKED=0 mise lock --yes --platform linux-x64,linux-x64-musl,linux-arm64,linux-arm64-musl,macos-x64,macos-arm64,windows-x64 -- {{{depName}}}'"
         ],
         "fileFilters": ["mise.lock"],
         "executionMode": "update"


### PR DESCRIPTION
## Summary

Fix Renovate's postUpgradeTasks for mise dependencies so that `mise.lock` is properly updated when dependency versions are bumped.

## Problem

PRs updating mise-managed dependencies (flyctl, cargo-llvm-cov, nextest, wrangler) were created with only `mise.toml` changes, missing the `mise.lock` updates. This happened because:

1. `mise.toml` has `locked = true` in settings
2. When Renovate runs `mise lock ...`, it fails with "mise lock is disabled in --locked mode"
3. The `MISE_LOCKED=0 mise lock ...` syntax doesn't work because Renovate doesn't execute commands through a shell

## Solution

Wrap the mise commands with `sh -c 'MISE_LOCKED=0 ...'` to:
1. Execute through a shell that can interpret environment variable syntax
2. Temporarily disable locked mode for the lock command

## Testing

Verified this fix works in https://github.com/altendky/test-renovatebot-post-upgrade-tasks - all mise dependency PRs now include both `mise.toml` and `mise.lock` changes.

## Affected PRs

After merging, these PRs should be rebased to get proper `mise.lock` updates:
- #304 (flyctl)
- #305 (cargo-llvm-cov)
- #306 (nextest)
- #308 (wrangler)