### PR TITLE
Align lychee pre-commit hook pin to tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,8 @@ repos:
     hooks:
       - id: markdownlint-cli2
 
-  # TODO: switch back to release tag once the shebang fix is released
-  #       https://github.com/lycheeverse/lychee/pull/2002
   - repo: https://github.com/lycheeverse/lychee
-    rev: 7bf09ac8f919719d36dfc50be15cb26e553a816c
+    rev: lychee-v0.23.0
     hooks:
       - id: lychee
         args: ["--no-progress", "--config=.lychee.toml"]


### PR DESCRIPTION
## Summary

- Switch lychee pre-commit hook `rev` from commit hash (`7bf09ac8f919719d36dfc50be15cb26e553a816c`) to release tag (`lychee-v0.23.0`)
- Remove the now-resolved TODO comment referencing lycheeverse/lychee#2002

The shebang fix from lycheeverse/lychee#2002 was merged on 2026-01-31 and included in the `lychee-v0.23.0` release (2026-02-13), so the commit hash pin is no longer needed.

Closes #335