### PR TITLE
Remove optionalDependencies from source — inject at publish time

### DIFF
--- a/.github/workflows/reflow-release-npm.yml
+++ b/.github/workflows/reflow-release-npm.yml
@@ -85,11 +85,21 @@ jobs:
             echo "Updating $pkg_json to $VERSION"
             # Update version field
             jq --arg v "$VERSION" '.version = $v' "$pkg_json" > tmp.json && mv tmp.json "$pkg_json"
-            # Update optionalDependencies versions if present
-            if jq -e '.optionalDependencies' "$pkg_json" > /dev/null 2>&1; then
-              jq --arg v "$VERSION" '.optionalDependencies |= with_entries(if .key | startswith("@onshape-mcp/") then .value = $v else . end)' "$pkg_json" > tmp.json && mv tmp.json "$pkg_json"
-            fi
           done
+
+          # Inject optionalDependencies into the main package.
+          # Source package.json has no optionalDependencies — they are
+          # injected here at publish time so the lockfile stays accurate
+          # during development (platform packages may not be published at
+          # the in-repo version).
+          main_json="npm/onshape-mcp/package.json"
+          opt_deps="{}"
+          for platform_dir in $PLATFORM_DIRS; do
+            platform_name=$(basename "$platform_dir")
+            opt_deps=$(echo "$opt_deps" | jq --arg k "@onshape-mcp/${platform_name}" --arg v "$VERSION" '. + {($k): $v}')
+          done
+          echo "Injecting optionalDependencies into $main_json: $opt_deps"
+          jq --argjson deps "$opt_deps" '.optionalDependencies = $deps' "$main_json" > tmp.json && mv tmp.json "$main_json"
 
       - name: Pack npm tarballs
         shell: bash

--- a/docs/src/project/npm-wrapper.md
+++ b/docs/src/project/npm-wrapper.md
@@ -62,7 +62,16 @@ npm/
 
 ### Optional Dependencies
 
-The main `onshape-mcp` package declares all platform packages as `optionalDependencies` (example showing illustrative version 0.1.0):
+The published `onshape-mcp` package declares all platform packages as `optionalDependencies`.
+npm only installs the optional dependency matching the current platform, keeping installation fast and lightweight.
+
+**Publish-time injection:** The source `package.json` does **not** contain `optionalDependencies`.
+They are injected by the CI publish workflow (`reflow-release-npm.yml`) at packaging time using `jq`.
+This avoids lockfile degradation during version bumps — since unpublished platform packages
+at the new version can't be resolved by `npm install`, keeping them out of the source
+`package.json` means the lockfile is always accurate.
+
+The published package looks like (example showing illustrative version 0.1.0):
 
 ```json
 {
@@ -76,8 +85,6 @@ The main `onshape-mcp` package declares all platform packages as `optionalDepend
   }
 }
 ```
-
-npm only installs the optional dependency matching the current platform, keeping installation fast and lightweight.
 
 ### JavaScript Shim
 
@@ -181,8 +188,9 @@ The npm packages are published as part of the release process:
 2. **Build binaries** — CI builds release binaries for all supported platforms
 3. **Validate versions** — CI job verifies all `package.json` versions match `Cargo.toml`
 4. **Prepare packages** — Copy binaries into their respective `npm/` platform directories
-5. **Publish platform packages** — Publish each `@onshape-mcp/*` package to npm
-6. **Publish main package** — Publish the main `onshape-mcp` package last
+5. **Inject optionalDependencies** — CI injects the `optionalDependencies` block into the main `package.json` with `jq`
+6. **Publish platform packages** — Publish each `@onshape-mcp/*` package to npm
+7. **Publish main package** — Publish the main `onshape-mcp` package last
 
 The main package must be published last to ensure all platform dependencies are available when users install it.
 

--- a/npm/onshape-mcp/package-lock.json
+++ b/npm/onshape-mcp/package-lock.json
@@ -19,13 +19,6 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "optionalDependencies": {
-        "@onshape-mcp/darwin-arm64": "0.3.0",
-        "@onshape-mcp/darwin-x64": "0.3.0",
-        "@onshape-mcp/linux-arm64": "0.3.0",
-        "@onshape-mcp/linux-x64": "0.3.0",
-        "@onshape-mcp/win32-x64": "0.3.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -75,71 +68,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@onshape-mcp/darwin-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@onshape-mcp/darwin-arm64/-/darwin-arm64-0.3.0.tgz",
-      "integrity": "sha512-cCrld5gG7LmSjtvdnBdec4lMRPFYb32k20jFFqiQV9zguWt+nLualavGfXRS27IUhKcImkUvgEpmajzQ1ePM8g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@onshape-mcp/darwin-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@onshape-mcp/darwin-x64/-/darwin-x64-0.3.0.tgz",
-      "integrity": "sha512-CyHE3p5vmnYecPaJsPFqefr7Zp/C/U6+fqoozxUraY2pl+yfDszswVaGZOb5vMoO95s0xC3Z95eWoFHPjkpa4A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@onshape-mcp/linux-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@onshape-mcp/linux-arm64/-/linux-arm64-0.3.0.tgz",
-      "integrity": "sha512-1qatP2az7I0c4AERLrREw5qEaeBhtD96I3gW08qX7iwZv/0y24TXLi6gIb1XrxPU7SpETuhjzmyUtBOtkK9Oeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@onshape-mcp/linux-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@onshape-mcp/linux-x64/-/linux-x64-0.3.0.tgz",
-      "integrity": "sha512-IdM0t+rOT274DhU6P4pt3AD+AOtN1RJlWJuMglGjYgaKOlZuWaicqZ2HEfVewybRNHZmZGPy00B90QXutt67GQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@onshape-mcp/win32-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@onshape-mcp/win32-x64/-/win32-x64-0.3.0.tgz",
-      "integrity": "sha512-8TA1elS3whSU1B44Fpdo0bvYf7L91qCq0M5tcwKdTb851GqNMswbNuEi6oOWnBWol4XlxxodhcDCI1/UEAsxlQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/npm/onshape-mcp/package.json
+++ b/npm/onshape-mcp/package.json
@@ -34,13 +34,6 @@
   "devDependencies": {
     "c8": "^11.0.0"
   },
-  "optionalDependencies": {
-    "@onshape-mcp/linux-x64": "0.3.0",
-    "@onshape-mcp/linux-arm64": "0.3.0",
-    "@onshape-mcp/darwin-x64": "0.3.0",
-    "@onshape-mcp/darwin-arm64": "0.3.0",
-    "@onshape-mcp/win32-x64": "0.3.0"
-  },
   "engines": {
     "node": ">=22"
   }

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -7,7 +7,7 @@
  * Propagates [workspace.package].version to:
  *   - [workspace.dependencies] internal crate version entries (root Cargo.toml)
  *   - Cargo.lock (via `cargo update --workspace`)
- *   - All npm package.json files and package-lock.json
+ *   - All npm package.json version fields and package-lock.json
  *
  * Usage:
  *   node scripts/sync-versions.js          # Update all version references
@@ -193,18 +193,6 @@ function updatePackageVersion(pkgPath, version) {
     changed = true;
   }
 
-  // Update optionalDependencies if present (main package)
-  if (pkg.optionalDependencies) {
-    for (const dep of Object.keys(pkg.optionalDependencies)) {
-      if (dep.startsWith("@onshape-mcp/")) {
-        if (pkg.optionalDependencies[dep] !== version) {
-          pkg.optionalDependencies[dep] = version;
-          changed = true;
-        }
-      }
-    }
-  }
-
   if (changed) {
     writePackageJson(pkgPath, pkg);
   }
@@ -218,14 +206,6 @@ function checkPackageVersion(pkgPath, version) {
 
   if (pkg.version !== version) {
     mismatches.push(`version: ${pkg.version} (expected ${version})`);
-  }
-
-  if (pkg.optionalDependencies) {
-    for (const [dep, depVersion] of Object.entries(pkg.optionalDependencies)) {
-      if (dep.startsWith("@onshape-mcp/") && depVersion !== version) {
-        mismatches.push(`${dep}: ${depVersion} (expected ${version})`);
-      }
-    }
   }
 
   return mismatches;
@@ -254,50 +234,38 @@ function checkLockfileVersion(lockPath, version) {
         `packages[""].version: ${rootPkg.version} (expected ${version})`,
       );
     }
-
-    if (rootPkg.optionalDependencies) {
-      for (const [dep, depVersion] of Object.entries(
-        rootPkg.optionalDependencies,
-      )) {
-        if (dep.startsWith("@onshape-mcp/") && depVersion !== version) {
-          mismatches.push(
-            `packages[""].optionalDependencies["${dep}"]: ${depVersion} (expected ${version})`,
-          );
-        }
-      }
-    }
   }
 
   return mismatches;
 }
 
-function updateNpmLockfile(pkgDir) {
-  const lockRelPath = path.relative(ROOT, path.join(pkgDir, "package-lock.json"));
+function updateNpmLockfile(pkgDir, version) {
+  const lockPath = path.join(pkgDir, "package-lock.json");
+  const lockRelPath = path.relative(ROOT, lockPath);
   console.log(`Updating ${lockRelPath}...`);
-  try {
-    const [cmd, args] =
-      process.platform === "win32"
-        ? ["cmd.exe", ["/c", "npm", "install", "--package-lock-only"]]
-        : ["npm", ["install", "--package-lock-only"]];
-    execFileSync(cmd, args, {
-      cwd: pkgDir,
-      stdio: "pipe",
-    });
-    console.log(`UPDATED: ${lockRelPath}`);
-    return true;
-  } catch (err) {
-    console.error(
-      `WARNING: Failed to update ${lockRelPath}:`,
-      err.message,
-    );
-    if (err.stderr) {
-      console.error("npm output:", err.stderr.toString());
-    }
-    console.error(
-      `  Run 'npm install' in ${path.relative(ROOT, pkgDir)}/ manually to fix.`,
-    );
-    return false;
+
+  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  let changed = false;
+
+  if (lock.version !== version) {
+    lock.version = version;
+    changed = true;
   }
+
+  const rootPkg = lock.packages?.[""];
+  if (rootPkg && rootPkg.version !== version) {
+    rootPkg.version = version;
+    changed = true;
+  }
+
+  if (changed) {
+    fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + "\n");
+    console.log(`UPDATED: ${lockRelPath}`);
+  } else {
+    console.log(`OK: ${lockRelPath} (no changes)`);
+  }
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -432,7 +400,7 @@ function main() {
       }
     }
   } else {
-    if (!updateNpmLockfile(mainPkgDir)) {
+    if (!updateNpmLockfile(mainPkgDir, version)) {
       hasErrors = true;
     }
   }


### PR DESCRIPTION
## Summary

- Remove `optionalDependencies` from source `npm/onshape-mcp/package.json` — inject the block at publish time in CI instead
- Replace `npm install --package-lock-only` in `sync-versions.js` with a targeted JSON edit of the lockfile version fields
- Regenerate `package-lock.json` (platform package entries removed entirely)

## Problem

When bumping versions for a release, `sync-versions.js` runs `npm install --package-lock-only` to regenerate the lockfile. Since the `@onshape-mcp/*` platform packages at the new version haven't been published to npm yet, npm can't resolve them and strips their lockfile entries to minimal stubs — losing `version`, `resolved`, `integrity`, and other fields. The committed lockfile is always degraded during version bump PRs.

## Solution

Adopt the **publish-time injection** strategy (as used by SWC, lightningcss, Bun):

1. **`npm/onshape-mcp/package.json`**: remove the `optionalDependencies` block from source
2. **`reflow-release-npm.yml`**: change the existing `jq` transform from patching `optionalDependencies` versions to injecting the entire block (built dynamically from the platform directories)
3. **`scripts/sync-versions.js`**: remove `optionalDependencies` patching from `updatePackageVersion`/`checkPackageVersion`/`checkLockfileVersion`; replace `npm install --package-lock-only` with a targeted JSON edit that only updates `version` fields in the lockfile
4. **`npm/onshape-mcp/package-lock.json`**: regenerated — the 5 platform package entries are removed entirely
5. **`docs/src/project/npm-wrapper.md`**: updated to document the publish-time injection strategy

## Verification

- `node scripts/sync-versions.js --check` passes
- `npm test` in `npm/onshape-mcp/` passes (42/42 tests)
- All pre-commit hooks pass (including `sync versions`)

Closes #362