### PR TITLE
Fix README and docs accuracy against implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ OAuth provides scoped, revocable access and is the better choice for ongoing use
 
 **With OpenCode (recommended):** Add the `@onshape-mcp/opencode-auth` plugin to your `opencode.json` (see the [OpenCode config example](#opencode) above), then run `opencode auth login`. The plugin will prompt for your client ID and secret, open a browser for authorization, and handle the rest.
 
-**With other MCP clients:** Pass the client credentials as environment variables and complete the OAuth flow manually:
+**With the CLI directly:** If you have the binary installed, run `onshape-mcp auth login` to complete the OAuth flow. By default this uses the [OAuth proxy](docs/src/project/oauth-proxy.md) so you don't need to provide a client secret. For direct mode (you supply your own client credentials), use `onshape-mcp auth login --direct`.
+
+**With other MCP clients:** Pass the client credentials as environment variables. The MCP server's `onshape_auth_login` tool can then initiate the OAuth flow from within the session.
 
 | Variable | Description |
 | -------- | ----------- |
@@ -237,6 +239,20 @@ cargo install onshape-mcp
 # Pre-built binaries
 # Download from https://github.com/altendky/onshape-mcp/releases
 ```
+
+## HTTP Transport
+
+For multi-user or remote deployments, the server also supports [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport with per-user OAuth authentication:
+
+```sh
+onshape-mcp http --host 0.0.0.0 --port 8080 \
+  --public-url https://your-domain.example \
+  --onshape-client-id <id> \
+  --onshape-client-secret <secret> \
+  --allowed-users user@example.com
+```
+
+This starts an MCP server at `/mcp` with a full OAuth 2.0 Authorization Server (RFC 8414, Dynamic Client Registration). A Dockerfile and Fly.io configuration are included for deployment. See the [Architecture docs](docs/src/project/architecture.md) for details.
 
 ## Documentation
 

--- a/docs/src/project/configuration.md
+++ b/docs/src/project/configuration.md
@@ -48,10 +48,11 @@ check_interval = "5m"
 [api]
 timeout = "30s"
 
-[mode]
-max = "read"
-initial = "read"
-allow_escalation = false
+# Planned — not yet implemented. See the implementation roadmap.
+# [mode]
+# max = "read"
+# initial = "read"
+# allow_escalation = false
 ```
 
 ## Environment Variables
@@ -66,12 +67,12 @@ All environment variables use the `ONSHAPE_MCP_` prefix.
 | Secret Key | `string` | — | `ONSHAPE_MCP_AUTH__SECRET_KEY` | `auth.secret_key` | `--secret-key` | Onshape API secret key |
 | Client ID | `string` | — | `ONSHAPE_MCP_AUTH__CLIENT_ID` | `auth.client_id` | `--client-id` | OAuth 2.0 client ID |
 | Client Secret | `string` | — | `ONSHAPE_MCP_AUTH__CLIENT_SECRET` | `auth.client_secret` | `--client-secret` | OAuth 2.0 client secret |
-| Auth Method | `string` | `basic` | `ONSHAPE_MCP_AUTH__METHOD` | `auth.method` | `--auth-method` | Authentication method (`basic`, `oauth`; HMAC planned) |
+| Auth Method | `string` | `auto` | `ONSHAPE_MCP_AUTH__METHOD` | `auth.method` | `--auth-method` | Authentication method (`auto`, `basic`, `oauth`; HMAC planned) |
 | Auth Check Interval | `duration` | `5m` | `ONSHAPE_MCP_AUTH__CHECK_INTERVAL` | `auth.check_interval` | — | Periodic credential validation interval (minimum: 15s) |
 | API Timeout | `duration` | `30s` | `ONSHAPE_MCP_API__TIMEOUT` | `api.timeout` | — | Request timeout for Onshape API calls |
-| Max Mode | `read`/`modify`/`destroy` | `read` | `ONSHAPE_MCP_MAX_MODE` | `mode.max` | — | Upper limit for permission mode |
-| Initial Mode | `read`/`modify`/`destroy` | `read` | `ONSHAPE_MCP_INITIAL_MODE` | `mode.initial` | — | Starting permission mode (must be ≤ max_mode) |
-| Allow Mode Escalation | `bool` | `false` | `ONSHAPE_MCP_ALLOW_ESCALATION` | `mode.allow_escalation` | — | Can AI change mode at runtime? |
+| Max Mode | `read`/`modify`/`destroy` | `read` | `ONSHAPE_MCP_MAX_MODE` | `mode.max` | — | *Planned, not yet implemented.* Upper limit for permission mode |
+| Initial Mode | `read`/`modify`/`destroy` | `read` | `ONSHAPE_MCP_INITIAL_MODE` | `mode.initial` | — | *Planned, not yet implemented.* Starting permission mode (must be ≤ max_mode) |
+| Allow Mode Escalation | `bool` | `false` | `ONSHAPE_MCP_ALLOW_ESCALATION` | `mode.allow_escalation` | — | *Planned, not yet implemented.* Can AI change mode at runtime? |
 
 ### Token File Location
 

--- a/docs/src/project/implementation.md
+++ b/docs/src/project/implementation.md
@@ -2,19 +2,20 @@
 
 ## Phase 1: Project Setup
 
-- [ ] Initialize Cargo workspace
-- [ ] Set up crate structure
-- [ ] Create rust-toolchain.toml
-- [ ] Configure linting (clippy.toml, rustfmt.toml)
-- [ ] Set up pre-commit hooks (.pre-commit-config.yaml, typos.toml)
-- [ ] Set up GitHub Actions CI
-- [x] Set up specs/ directory with OpenAPI spec and license
+- [x] Initialize Cargo workspace
+- [x] Set up crate structure (6 crates: onshape-client-core, onshape-client-io, onshape-mcp-core, onshape-mcp-io, onshape-mcp-resources, onshape-mcp)
+- [x] Create rust-toolchain.toml
+- [x] Configure linting (workspace Cargo.toml lints, rustfmt.toml)
+- [x] Set up pre-commit hooks (.pre-commit-config.yaml, typos.toml)
+- [x] Set up GitHub Actions CI (ci.yml with reflow workflows)
+- [x] Embed OpenAPI spec (`crates/onshape-mcp-io/onshape-openapi.json`)
 - [ ] Create update-openapi-spec.yml workflow
-- [ ] Configure GitHub App for CI triggering
-- [ ] Add license files
-- [ ] Create initial README
+- [x] Add license files (LICENSE-MIT, LICENSE-APACHE)
+- [x] Create initial README
 
-## Phase 1.5: Tracing Infrastructure
+## Phase 1.5: Tracing Infrastructure (Deferred)
+
+Sans-IO tracing was planned but has not been started.
 
 - [ ] Create `crates/tracing-sansio/Cargo.toml`
 - [ ] Implement `Captured<T>` type and `capture_tracing()` function
@@ -26,31 +27,54 @@
 
 ## Phase 2: Core Implementation
 
-- [ ] Define effect types in `onshape-mcp-core`
-- [ ] Implement MCP handler state machine
+- [x] Define effect types in `onshape-mcp-core` (`ToolEffect`, `Continuation`)
+- [x] Implement MCP handler state machine (`handle_tool_call`)
 - [ ] Implement permission model (modes, escalation)
-- [ ] Define Onshape API types in `onshape-client-core`
+- [x] Define Onshape API types in `onshape-client-core`
 - [x] Implement generic API tools (`onshape_api_search`, `onshape_api_explain`, `onshape_api_call`)
+- [x] Implement `onshape_api_schema` tool (schema lookup with polymorphic types, discriminators)
 - [x] Implement OpenAPI spec parsing and indexing
 - [x] Implement effects-as-data pattern for `ToolResult`
-- [ ] Implement server admin tools (`onshape_mcp_get_mode`, `onshape_mcp_request_mode`)
+- [x] Implement `onshape_mcp_get_started` tool (onboarding guidance)
+- [x] Implement `onshape_auth_status` tool (auth state reporting)
+- [x] Implement `onshape_auth_login` tool (OAuth login flow via effects)
+- [x] Implement `onshape_screenshot` tool (Part Studio rendering)
+- [x] Implement `onshape_error_lookup` tool (FeatureScript error enum resolution)
+- [x] Implement resource system (`onshape_list_resources`, `onshape_read_resource`) with compile-time embedded insights
+- [x] Implement file reference support in `onshape_api_call` (text, base64, raw bytes encodings)
+- [ ] Implement server admin tools (`onshape_mcp_get_mode`, `onshape_mcp_request_mode`) — blocked on permission model
 - [ ] Write comprehensive unit tests for core crates
 
 ## Phase 3: I/O Integration
 
-- [ ] Implement transport layer in `onshape-mcp-io`
+- [x] Implement stdio transport in `onshape-mcp-io`
+- [x] Implement Streamable HTTP transport (`onshape-mcp http` subcommand) with per-user OAuth
 - [x] Implement HTTP client in `onshape-client-io`
 - [x] Wire up `onshape_api_call` effect execution in I/O layer
 - [x] Wire up in main binary
+- [x] Implement `auth login` CLI subcommand (local callback server, PKCE, CSRF)
+- [x] Implement token file watching (inotify/kqueue/ReadDirectoryChanges with polling fallback)
+- [x] Implement proactive and reactive OAuth token refresh (direct and proxy modes)
+- [x] Implement config file permission enforcement (0600 on Unix)
 
 ## Phase 4: Polish
 
-- [ ] Add documentation
-- [ ] Set up coverage reporting
+- [x] Add documentation (project docs, knowledge base, MCP resource insights)
+- [x] Set up coverage reporting (codecov.yml, cargo-llvm-cov workflow)
 - [ ] Add integration tests
 - [ ] Performance testing
 
-## Phase 5: OAuth Token Exchange Proxy
+## Phase 5: Distribution
+
+- [x] Create npm wrapper package (`npm/onshape-mcp/`) with cross-platform binary downloads
+- [x] Create OpenCode auth plugin (`npm/opencode-auth/`)
+- [x] Set up cross-platform release builds (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64)
+- [x] Set up GitHub Release automation (archives, SHA256SUMS)
+- [x] Set up crates.io publishing
+- [x] Set up npm publishing (with staging validation)
+- [x] Create Dockerfile and Fly.io deployment for HTTP transport
+
+## Phase 6: OAuth Token Exchange Proxy
 
 - [x] Create `workers/oauth-proxy/` project structure (wrangler.toml, package.json, tsconfig.json)
 - [x] Implement pure handler (`src/handler.ts`) with request routing and validation
@@ -70,6 +94,6 @@
 - [ ] Configure `ALLOWED_SOURCES` in Cloudflare dashboard
 - [ ] Verify all endpoints with curl
 
-## Phase 6: FeatureScript (Future)
+## Phase 7: FeatureScript (Future)
 
 - [ ] Implement FeatureScript-related API endpoints (accessible via `onshape_api_call`)


### PR DESCRIPTION
## Summary

- **configuration.md**: Correct auth method default from `basic` to `auto` (matching `DEFAULTS_TOML` and `default_auth_method()`)
- **configuration.md**: Mark `mode.*` permission settings as planned/not yet implemented (commented out in example, italic note in reference table)
- **implementation.md**: Overhaul roadmap to reflect current state — check off ~30 completed items, add missing features (all 11 tools, both transports, distribution pipeline, auth CLI, token watching, permission enforcement), mark Phase 1.5 tracing as deferred, add new Phase 5 for distribution
- **README**: Document `onshape-mcp auth login` CLI subcommand as an OAuth option alongside the OpenCode plugin
- **README**: Add HTTP Transport section documenting `onshape-mcp http` for Streamable HTTP deployment