### PR TITLE
Rewrite README for CAD engineer audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ is either `npx --yes onshape-mcp` or the path to the downloaded binary.
 **Step 3: Try it**
 
 Ask your AI assistant to create a new Onshape document with a simple shape. If
-you haven't authenticated yet, it will open a browser window for you to log into
-Onshape and approve access.
+you haven't authenticated yet, it will give you a URL to open in your browser to
+log into Onshape and approve access.
 
 ### Web Setup (Claude.ai or other web MCP clients)
 


### PR DESCRIPTION
## Summary

- Refocuses the README on the end-to-end user journey for CAD engineers who know Onshape, not developers
- Auth is now invisible to users — happens in-session via the token relay, so MCP client configs no longer include credentials or env vars
- Presents two setup paths: local stdio (recommended, with filesystem access for screenshots/exports/FeatureScript) and hosted web (zero install, but higher token usage since file content goes through the conversation)
- Adds a "Tips" section for effective usage and a "What You Can Do" section describing capabilities in user language
- Marks the project as in a closed testing period ("Don't call us, we'll call you")

## Removed

Badges, tool reference tables, JSON workflow examples, all auth setup instructions (API keys, OAuth app creation, env vars, plugin config), permission model section, configuration reference, `cargo install`, HTTP self-hosting, and architecture details. These belong in project docs, not the user-facing README.