### PR TITLE
Use tag-specific ref check in release task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -71,7 +71,7 @@ git pull --ff-only
 
 # Check tag doesn't already exist
 git fetch --tags
-if git rev-parse "v${version}" >/dev/null 2>&1; then
+if git show-ref --verify --quiet "refs/tags/v${version}"; then
   echo "Error: tag v${version} already exists" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Replace `git rev-parse` with `git show-ref --verify` in the release task's tag existence check, so only tag refs are matched — avoiding false positives from branches that share the tag name.

Closes #374