### PR TITLE
Update rustls-webpki for RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,9 +1919,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Update rustls-webpki from 0.103.10 to 0.103.13 to address the current RustSec advisories reported by cargo-deny.

## Verification
- cargo deny check