### PR TITLE
Fix Clippy collapsible match lint

### DIFF
--- a/crates/onshape-mcp-resources/build.rs
+++ b/crates/onshape-mcp-resources/build.rs
@@ -162,16 +162,14 @@ fn parse_index(index_path: &Path) -> Vec<ResourceEntry> {
                     }
                 }
             }
-            Event::Code(code) => {
-                if in_list_item {
-                    current_item_text.push('`');
-                    current_item_text.push_str(&code);
-                    current_item_text.push('`');
-                    if in_link {
-                        current_link_title.push('`');
-                        current_link_title.push_str(&code);
-                        current_link_title.push('`');
-                    }
+            Event::Code(code) if in_list_item => {
+                current_item_text.push('`');
+                current_item_text.push_str(&code);
+                current_item_text.push('`');
+                if in_link {
+                    current_link_title.push('`');
+                    current_link_title.push_str(&code);
+                    current_link_title.push('`');
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary
- Collapse the `Event::Code` list-item handling into a guarded match arm to satisfy Rust 1.96 Clippy.
- Keep behavior unchanged while fixing the `clippy::collapsible-match` failure from the Rust / Lint job.

## Testing
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`