### PR TITLE
Fix Clippy trailing comma lint

### DIFF
--- a/crates/onshape-mcp-io/src/login.rs
+++ b/crates/onshape-mcp-io/src/login.rs
@@ -810,7 +810,7 @@ async fn fetch_proxy_client_id(proxy_url: &str) -> Result<String, LoginError> {
                 Ok(ForbiddenBody {
                     source_ip: Some(ip),
                 }) => {
-                    format!("your IP address ({ip}) is not authorized to use this proxy",)
+                    format!("your IP address ({ip}) is not authorized to use this proxy")
                 }
                 _ => format!("HTTP {status}: {body}"),
             }


### PR DESCRIPTION
## Summary
- Remove the trailing comma in a single-argument `format!` call so Rust 1.96 Clippy passes with `-D warnings`.

## Verification
- `cargo fmt --all --check && cargo clippy --all-targets --all-features -- -D warnings`