### PR TITLE
update mergify action to v18

### DIFF
--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload test results to Mergify CI Insights
         if: (success() || failure()) && env.MERGIFY_TOKEN_AVAILABLE == 'true'
-        uses: mergifyio/gha-mergify-ci@62b45952da6270cad56cce30b8d63276f9d99c88 # v16
+        uses: mergifyio/gha-mergify-ci@3a9f130da423bb1a2d56f0e4b34de26e9fa3558d # v18
         with:
           token: ${{ secrets.MERGIFY_TOKEN }}
           report_path: target/nextest/ci/junit.xml

--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -181,8 +181,6 @@ jobs:
       - name: Upload test results to Mergify CI Insights
         if: (success() || failure()) && env.MERGIFY_TOKEN_AVAILABLE == 'true'
         uses: mergifyio/gha-mergify-ci@3a9f130da423bb1a2d56f0e4b34de26e9fa3558d # v18
-        env:
-          MERGIFY_PYTHON_EXE: python
         with:
           token: ${{ secrets.MERGIFY_TOKEN }}
           report_path: target/nextest/ci/junit.xml

--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -181,6 +181,8 @@ jobs:
       - name: Upload test results to Mergify CI Insights
         if: (success() || failure()) && env.MERGIFY_TOKEN_AVAILABLE == 'true'
         uses: mergifyio/gha-mergify-ci@3a9f130da423bb1a2d56f0e4b34de26e9fa3558d # v18
+        env:
+          MERGIFY_PYTHON_EXE: python
         with:
           token: ${{ secrets.MERGIFY_TOKEN }}
           report_path: target/nextest/ci/junit.xml


### PR DESCRIPTION
## Summary
- Update the Rust workflow to use Mergify CI action v18.
- Avoid the v16 path that installed the latest `mergify-cli` and failed on Windows after tests passed.

## Testing
- `git diff --check`
- Commit hooks: YAML checks, GitHub Actions workflow linting, and workflow validation passed.