### PR TITLE
ci(mergify): queue approved enqueue PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,15 @@ merge_queue:
   max_parallel_checks: 1
 
 pull_request_rules:
+  - name: Queue approved enqueue PRs
+    conditions:
+      - base = main
+      - label = enqueue
+      - "#approved-reviews-by >= 1"
+    actions:
+      queue:
+        name: default
+
   - name: Automatically approve Renovate PRs
     conditions:
       - author = altendky-renovate[bot]
@@ -36,5 +45,4 @@ pull_request_rules:
       review:
         type: APPROVE
 merge_protections_settings:
-  auto_merge_conditions: true
   reporting_method: check-runs

--- a/docs/src/project/ci.md
+++ b/docs/src/project/ci.md
@@ -26,13 +26,14 @@ the repository root.
 **How it works:**
 
 1. Apply the `enqueue` label to a PR
-2. Once the PR has an approval, Mergify Merge Protections auto-queues it
+2. Once the PR has an approval, Mergify Workflow Automation queues it
 3. Mergify creates a temporary branch merging the PR into `main` and runs CI again
 4. If branch protection passes on the queued merge, Mergify merges the PR
 5. If CI fails, the PR is dequeued
 
 This schedules PRs after approval while keeping branch protection checks on the queued merge
-result, so `main` is protected without requiring PR branches to stay up to date manually.
+result. Mergify Merge Protections reports the same approval gate as a required status check,
+so `main` is protected without requiring PR branches to stay up to date manually.
 
 **Flaky failure handling:**
 
@@ -44,7 +45,8 @@ limits) without manual intervention.
 | ------- | ----- |
 | Configuration | `.mergify.yml` |
 | Queue entry | `enqueue` label + 1 approval |
-| Autoqueue gate | Mergify Merge Protections |
+| Queue action | Mergify Workflow Automation `queue` action |
+| Merge protection | `Mergify Merge Protections` required status check |
 | Merge gate | GitHub branch protection (`all`) injected into queue merge conditions |
 | Merge method | Merge commits |
 | Checks timeout | 90 minutes |

--- a/docs/src/project/ci.md
+++ b/docs/src/project/ci.md
@@ -10,7 +10,7 @@ This section documents the manual configuration required in GitHub repository se
 | --------- | ------- |
 | Require PR before merge | Yes |
 | Required approvals | 0 (increase when contributors join) |
-| Require status checks | Yes — `all` job only |
+| Require status checks | Yes — `all` job + `Mergify Merge Protections` |
 | Require merge queue | No (Mergify handles this) |
 | Require branches up-to-date | No (Mergify merge queue handles this) |
 | Show update branch button | Always |


### PR DESCRIPTION
## Summary
- Add an explicit Mergify Workflow Automation `queue` action for approved PRs labeled `enqueue`
- Keep Mergify Merge Protections as the required approval gate/status check
- Remove the non-firing `auto_merge_conditions` path and update CI docs accordingly

## Findings
- `mergify queue status --json` showed the queue was empty and unpaused
- Mergify event logs for #384 showed only refresh events, with no queue attempt
- `mergify config simulate` now shows `Queue approved enqueue PRs (queue)` matching #384

## Validation
- `pre-commit run check-yaml --files .mergify.yml`
- `pre-commit run validate-mergify-config --files .mergify.yml`
- `pre-commit run markdownlint-cli2 --files docs/src/project/ci.md`
- `mergify config simulate -t "$(gh auth token)" https://github.com/altendky/onshape-mcp/pull/384`
- `git diff --check`