### PR TITLE
ci(mergify): use deployments reporting

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,3 +36,6 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
+
+merge_protections_settings:
+  reporting_method: deployments


### PR DESCRIPTION
## Summary

- explicitly opt into Mergify Merge Protections deployment reporting
- avoids preserving the old check-runs default from Mergify's migration PR

## Validation

- pre-commit run check-yaml --files .mergify.yml
- pre-commit run validate-mergify-config --files .mergify.yml
- mergify config simulate -t "$(gh auth token)" https://github.com/altendky/onshape-mcp/pull/384
- mergify config simulate -t "$(gh auth token)" https://github.com/altendky/onshape-mcp/pull/402