### PR TITLE
ci(renovate): allow mise lock execution

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,4 +43,5 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '[".*"]'
+          RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}


### PR DESCRIPTION
## Summary

- allow Renovate's self-hosted unsafe execution category for mise
- fixes the Dependency Dashboard warning that mise lock was requested but mise was not permitted in allowedUnsafeExecutions

## Validation

- mise x -- pre-commit run check-yaml --files .github/workflows/renovate.yml
- mise x -- pre-commit run actionlint --files .github/workflows/renovate.yml
- mise x -- pre-commit run action-validator --files .github/workflows/renovate.yml
- git commit hooks