### PR TITLE
ci(renovate): resolve action warnings

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
@@ -44,4 +44,5 @@ jobs:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '[".*"]'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
+          RENOVATE_BINARY_SOURCE: global
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,9 +40,9 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           docker-volumes: /tmp:/tmp;${{ steps.mise-path.outputs.bin }}:/usr/local/bin/mise
+          docker-user: 12021:0
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ALLOWED_COMMANDS: '[".*"]'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
-          RENOVATE_BINARY_SOURCE: global
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}


### PR DESCRIPTION
## Summary

- switch create-github-app-token from deprecated app-id input to client-id
- run the Renovate container as UID 12021 with GID 0 so Containerbase install-tool can write tool shims while preserving Renovate's default binarySource=install behavior

## Context

Addresses warnings from https://github.com/altendky/onshape-mcp/actions/runs/27030594647:

- Input 'app-id' has been deprecated with message: Use 'client-id' instead.
- Error updating mise.lock due to install-tool trying to write /opt/containerbase/bin/mise without permission

A broader RENOVATE_BINARY_SOURCE=global approach was rejected because the Renovate image does not provide all needed artifact tools globally.

## Validation

- mise x -- pre-commit run check-yaml --files .github/workflows/renovate.yml
- mise x -- pre-commit run actionlint --files .github/workflows/renovate.yml
- mise x -- pre-commit run action-validator --files .github/workflows/renovate.yml
- docker run --rm --user 12021:0 ghcr.io/renovatebot/renovate:43 bash -lc 'id && ls -ld /opt/containerbase/bin && install-tool mise v2026.6.0'
- git commit hooks