### PR TITLE
ci(renovate): let containerbase install mise

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,22 +24,9 @@ jobs:
           client-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
-        with:
-          install: false
-
-      - id: mise-path
-        run: |
-          bin=$(which mise)
-          if [[ -z "$bin" ]]; then
-            echo "::error::mise binary not found in PATH"
-            exit 1
-          fi
-          echo "bin=$bin" >> "$GITHUB_OUTPUT"
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ steps.app-token.outputs.token }}
-          docker-volumes: /tmp:/tmp;${{ steps.mise-path.outputs.bin }}:/usr/local/bin/mise
           docker-user: 12021:0
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'


### PR DESCRIPTION
## Summary

- remove the host mise setup and bind mount from the Renovate workflow
- keep Renovate running as 12021:0 so Containerbase can install tools into /opt/containerbase/bin

## Context

Run https://github.com/altendky/onshape-mcp/actions/runs/27033895157 still failed to update mise.lock. The previous workflow mounted host mise at /usr/local/bin/mise, but inside the Renovate image /usr/local/bin is a symlink to /opt/containerbase/bin. That made /opt/containerbase/bin/mise a bind-mounted root-owned file, so Containerbase install-tool could not overwrite it.

Issue #138 did not update because the repository problems were unchanged: Renovate still emitted Error updating mise.lock and Detected empty commit.

## Validation

- mise x -- pre-commit run check-yaml --files .github/workflows/renovate.yml
- mise x -- pre-commit run actionlint --files .github/workflows/renovate.yml
- mise x -- pre-commit run action-validator --files .github/workflows/renovate.yml
- docker run --rm --user 12021:0 ghcr.io/renovatebot/renovate:43 bash -lc 'id && ls -ld /usr/local/bin /opt/containerbase/bin && install-tool mise v2026.6.0'
- git commit hooks