### PR TITLE
Use standard http types for client boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
+ "http",
  "oauth2",
  "schemars",
  "secrecy",
@@ -1319,6 +1320,7 @@ dependencies = [
 name = "onshape-client-io"
 version = "0.4.0"
 dependencies = [
+ "http",
  "oauth2",
  "onshape-client-core",
  "reqwest",
@@ -1349,6 +1351,7 @@ version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
+ "http",
  "onshape-client-core",
  "onshape-mcp-resources",
  "onshape-openapi",
@@ -1411,6 +1414,7 @@ name = "onshape-openapi"
 version = "0.4.0"
 dependencies = [
  "base64",
+ "http",
  "onshape-client-core",
  "schemars",
  "serde",

--- a/crates/onshape-client-core/Cargo.toml
+++ b/crates/onshape-client-core/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["api-bindings"]
 base64.workspace = true
 chrono.workspace = true
 oauth2.workspace = true
+http.workspace = true
 schemars.workspace = true
 secrecy.workspace = true
 serde.workspace = true

--- a/crates/onshape-client-core/src/endpoints.rs
+++ b/crates/onshape-client-core/src/endpoints.rs
@@ -6,8 +6,8 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
-use crate::request::{ApiRequest, ApiResponse, HttpMethod, RequestBody};
-use http::HeaderMap;
+use crate::request::{ApiRequest, ApiResponse, RequestBody};
+use http::{HeaderMap, Method};
 
 const JSON_CONTENT_TYPE: &str = "application/json;charset=UTF-8; qs=0.09";
 
@@ -269,7 +269,7 @@ pub fn create_assembly_export_step<P: Serialize + ?Sized>(
 #[must_use]
 pub fn get_translation(translation_id: &str) -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::GET,
+        method: Method::GET,
         path: format!("/translations/{}", encode_path_segment(translation_id)),
         query_params: Vec::new(),
         headers: HeaderMap::new(),
@@ -284,7 +284,7 @@ pub fn get_translation(translation_id: &str) -> ApiRequest {
 #[must_use]
 pub fn get_all_translator_formats() -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::GET,
+        method: Method::GET,
         path: "/translations/translationformats".to_string(),
         query_params: Vec::new(),
         headers: HeaderMap::new(),
@@ -303,7 +303,7 @@ pub fn get_all_translator_formats() -> ApiRequest {
 #[must_use]
 pub fn download_external_data(document_id: &str, foreign_id: &str) -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::GET,
+        method: Method::GET,
         path: format!(
             "/documents/d/{}/externaldata/{}",
             encode_path_segment(document_id),
@@ -337,7 +337,7 @@ fn json_post<P: Serialize + ?Sized>(path: String, params: &P) -> Result<ApiReque
     }
 
     Ok(ApiRequest {
-        method: HttpMethod::POST,
+        method: Method::POST,
         path,
         query_params: Vec::new(),
         headers: HeaderMap::new(),
@@ -391,7 +391,7 @@ mod tests {
     }
 
     fn assert_json_post(request: &ApiRequest, path: &str, format_name: &str) {
-        assert_eq!(request.method, HttpMethod::POST);
+        assert_eq!(request.method, Method::POST);
         assert_eq!(request.path, path);
         assert!(request.query_params.is_empty());
         assert_eq!(request.content_type.as_deref(), Some(JSON_CONTENT_TYPE));
@@ -491,7 +491,7 @@ mod tests {
     fn get_translation_builds_golden_request() {
         let request = get_translation("translation/1");
 
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, Method::GET);
         assert_eq!(request.path, "/translations/translation%2F1");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -502,7 +502,7 @@ mod tests {
     fn get_all_translator_formats_builds_golden_request() {
         let request = get_all_translator_formats();
 
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, Method::GET);
         assert_eq!(request.path, "/translations/translationformats");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -513,7 +513,7 @@ mod tests {
     fn download_external_data_builds_golden_request() {
         let request = download_external_data("doc/1", "file name.step");
 
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, Method::GET);
         assert_eq!(
             request.path,
             "/documents/d/doc%2F1/externaldata/file%20name.step"

--- a/crates/onshape-client-core/src/endpoints.rs
+++ b/crates/onshape-client-core/src/endpoints.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 use crate::request::{ApiRequest, ApiResponse, HttpMethod, RequestBody};
+use http::HeaderMap;
 
 const JSON_CONTENT_TYPE: &str = "application/json;charset=UTF-8; qs=0.09";
 
@@ -268,9 +269,10 @@ pub fn create_assembly_export_step<P: Serialize + ?Sized>(
 #[must_use]
 pub fn get_translation(translation_id: &str) -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::Get,
+        method: HttpMethod::GET,
         path: format!("/translations/{}", encode_path_segment(translation_id)),
         query_params: Vec::new(),
+        headers: HeaderMap::new(),
         body: None,
         content_type: None,
     }
@@ -282,9 +284,10 @@ pub fn get_translation(translation_id: &str) -> ApiRequest {
 #[must_use]
 pub fn get_all_translator_formats() -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::Get,
+        method: HttpMethod::GET,
         path: "/translations/translationformats".to_string(),
         query_params: Vec::new(),
+        headers: HeaderMap::new(),
         body: None,
         content_type: None,
     }
@@ -294,22 +297,20 @@ pub fn get_all_translator_formats() -> ApiRequest {
 ///
 /// `OpenAPI` operation ID: `downloadExternalData`.
 ///
-/// The optional `If-None-Match` header is intentionally not modeled because
-/// [`ApiRequest`] does not support request headers yet.
-///
-/// This also means callers cannot request a specific response media type through
-/// this helper yet; verify executor `Accept` behavior before relying on it for
-/// binary artifact downloads.
+/// This helper does not set `If-None-Match` or `Accept` yet. Callers that need
+/// cache validation or media negotiation can add request headers before
+/// executing the returned request.
 #[must_use]
 pub fn download_external_data(document_id: &str, foreign_id: &str) -> ApiRequest {
     ApiRequest {
-        method: HttpMethod::Get,
+        method: HttpMethod::GET,
         path: format!(
             "/documents/d/{}/externaldata/{}",
             encode_path_segment(document_id),
             encode_path_segment(foreign_id)
         ),
         query_params: Vec::new(),
+        headers: HeaderMap::new(),
         body: None,
         content_type: None,
     }
@@ -336,9 +337,10 @@ fn json_post<P: Serialize + ?Sized>(path: String, params: &P) -> Result<ApiReque
     }
 
     Ok(ApiRequest {
-        method: HttpMethod::Post,
+        method: HttpMethod::POST,
         path,
         query_params: Vec::new(),
+        headers: HeaderMap::new(),
         body: Some(RequestBody::Json(body)),
         content_type: Some(JSON_CONTENT_TYPE.to_string()),
     })
@@ -389,7 +391,7 @@ mod tests {
     }
 
     fn assert_json_post(request: &ApiRequest, path: &str, format_name: &str) {
-        assert_eq!(request.method, HttpMethod::Post);
+        assert_eq!(request.method, HttpMethod::POST);
         assert_eq!(request.path, path);
         assert!(request.query_params.is_empty());
         assert_eq!(request.content_type.as_deref(), Some(JSON_CONTENT_TYPE));
@@ -489,7 +491,7 @@ mod tests {
     fn get_translation_builds_golden_request() {
         let request = get_translation("translation/1");
 
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(request.path, "/translations/translation%2F1");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -500,7 +502,7 @@ mod tests {
     fn get_all_translator_formats_builds_golden_request() {
         let request = get_all_translator_formats();
 
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(request.path, "/translations/translationformats");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -511,7 +513,7 @@ mod tests {
     fn download_external_data_builds_golden_request() {
         let request = download_external_data("doc/1", "file name.step");
 
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(
             request.path,
             "/documents/d/doc%2F1/externaldata/file%20name.step"
@@ -553,8 +555,11 @@ mod tests {
     #[test]
     fn parse_translation_request_info_reads_export_result() {
         let response = ApiResponse {
-            status: 200,
-            headers: vec![("content-type".to_string(), JSON_CONTENT_TYPE.to_string())],
+            status: http::StatusCode::OK,
+            headers: HeaderMap::from_iter([(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static(JSON_CONTENT_TYPE),
+            )]),
             body: ResponseBody::from(
                 json!({
                     "documentId": "doc",
@@ -579,8 +584,8 @@ mod tests {
     #[test]
     fn parse_translation_request_info_rejects_invalid_json() {
         let response = ApiResponse {
-            status: 200,
-            headers: Vec::new(),
+            status: http::StatusCode::OK,
+            headers: HeaderMap::new(),
             body: ResponseBody::from("not json"),
         };
 
@@ -593,8 +598,8 @@ mod tests {
     #[test]
     fn parse_translation_request_info_preserves_unknown_state() {
         let response = ApiResponse {
-            status: 200,
-            headers: Vec::new(),
+            status: http::StatusCode::OK,
+            headers: HeaderMap::new(),
             body: ResponseBody::from(json!({ "requestState": "QUEUED" }).to_string()),
         };
 

--- a/crates/onshape-client-core/src/request.rs
+++ b/crates/onshape-client-core/src/request.rs
@@ -24,6 +24,11 @@ fn parse_method_case_insensitive(s: &str) -> Result<Method, UnknownHttpMethod> {
         .map_err(|_| UnknownHttpMethod(s.to_string()))
 }
 
+// `ApiRequest` serde is primarily for test and inspection ergonomics: internal
+// tests assert the request shape, and external consumers can serialize requests
+// in their own tests/debug tooling. Runtime request execution uses the typed
+// fields directly, so these helpers preserve that plain-data surface while the
+// boundary uses standard `http` types.
 mod method_serde {
     use serde::{Deserialize, Deserializer, Serializer};
 
@@ -45,6 +50,8 @@ mod method_serde {
     }
 }
 
+// See `method_serde` for why `ApiRequest` keeps serde support around `http`
+// protocol types.
 mod request_headers_serde {
     use std::str;
 

--- a/crates/onshape-client-core/src/request.rs
+++ b/crates/onshape-client-core/src/request.rs
@@ -14,9 +14,6 @@ use serde_json::Value;
 // HTTP Method
 // ============================================================================
 
-/// HTTP method for an API request.
-pub use http::Method as HttpMethod;
-
 /// Error returned when parsing an unrecognized HTTP method string.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("unknown HTTP method: {0}")]
@@ -98,7 +95,7 @@ mod request_headers_serde {
 pub struct ApiRequest {
     /// HTTP method.
     #[serde(with = "method_serde")]
-    pub method: HttpMethod,
+    pub method: Method,
     /// Fully resolved URL path (path params substituted), e.g. `/documents/abc123`.
     pub path: String,
     /// Query parameters.
@@ -259,29 +256,23 @@ mod tests {
 
     #[test]
     fn http_method_from_str_lowercase() {
-        assert_eq!(parse_method_case_insensitive("get"), Ok(HttpMethod::GET));
-        assert_eq!(parse_method_case_insensitive("post"), Ok(HttpMethod::POST));
-        assert_eq!(parse_method_case_insensitive("put"), Ok(HttpMethod::PUT));
-        assert_eq!(
-            parse_method_case_insensitive("delete"),
-            Ok(HttpMethod::DELETE)
-        );
-        assert_eq!(
-            parse_method_case_insensitive("patch"),
-            Ok(HttpMethod::PATCH)
-        );
+        assert_eq!(parse_method_case_insensitive("get"), Ok(Method::GET));
+        assert_eq!(parse_method_case_insensitive("post"), Ok(Method::POST));
+        assert_eq!(parse_method_case_insensitive("put"), Ok(Method::PUT));
+        assert_eq!(parse_method_case_insensitive("delete"), Ok(Method::DELETE));
+        assert_eq!(parse_method_case_insensitive("patch"), Ok(Method::PATCH));
     }
 
     #[test]
     fn http_method_from_str_uppercase() {
-        assert_eq!(parse_method_case_insensitive("GET"), Ok(HttpMethod::GET));
-        assert_eq!(parse_method_case_insensitive("POST"), Ok(HttpMethod::POST));
+        assert_eq!(parse_method_case_insensitive("GET"), Ok(Method::GET));
+        assert_eq!(parse_method_case_insensitive("POST"), Ok(Method::POST));
     }
 
     #[test]
     fn http_method_from_str_mixed_case() {
-        assert_eq!(parse_method_case_insensitive("Get"), Ok(HttpMethod::GET));
-        assert_eq!(parse_method_case_insensitive("PoSt"), Ok(HttpMethod::POST));
+        assert_eq!(parse_method_case_insensitive("Get"), Ok(Method::GET));
+        assert_eq!(parse_method_case_insensitive("PoSt"), Ok(Method::POST));
     }
 
     #[test]
@@ -291,17 +282,17 @@ mod tests {
 
     #[test]
     fn http_method_display() {
-        assert_eq!(HttpMethod::GET.to_string(), "GET");
-        assert_eq!(HttpMethod::POST.to_string(), "POST");
-        assert_eq!(HttpMethod::PUT.to_string(), "PUT");
-        assert_eq!(HttpMethod::DELETE.to_string(), "DELETE");
-        assert_eq!(HttpMethod::PATCH.to_string(), "PATCH");
+        assert_eq!(Method::GET.to_string(), "GET");
+        assert_eq!(Method::POST.to_string(), "POST");
+        assert_eq!(Method::PUT.to_string(), "PUT");
+        assert_eq!(Method::DELETE.to_string(), "DELETE");
+        assert_eq!(Method::PATCH.to_string(), "PATCH");
     }
 
     #[test]
     fn api_request_serializes() {
         let req = ApiRequest {
-            method: HttpMethod::GET,
+            method: Method::GET,
             path: "/documents/abc123".to_string(),
             query_params: vec![("limit".to_string(), "10".to_string())],
             headers: HeaderMap::new(),
@@ -316,7 +307,7 @@ mod tests {
     #[test]
     fn api_request_with_json_body_serializes() {
         let req = ApiRequest {
-            method: HttpMethod::POST,
+            method: Method::POST,
             path: "/documents".to_string(),
             query_params: vec![],
             headers: HeaderMap::new(),

--- a/crates/onshape-client-core/src/request.rs
+++ b/crates/onshape-client-core/src/request.rs
@@ -4,9 +4,9 @@
 //! The I/O layer (`onshape-client-io`) interprets these to make actual HTTP calls.
 
 use std::borrow::Cow;
-use std::str::{self, FromStr, Utf8Error};
+use std::str::{self, Utf8Error};
 
-use schemars::JsonSchema;
+use http::{HeaderMap, Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -15,50 +15,73 @@ use serde_json::Value;
 // ============================================================================
 
 /// HTTP method for an API request.
-///
-/// JSON serialization/deserialization is **uppercase-only** (via `serde(rename_all = "UPPERCASE")`),
-/// matching the HTTP convention for method tokens in structured payloads.
-/// [`FromStr`] is **case-insensitive** (e.g. `"get"`, `"Get"`, `"GET"` all parse successfully),
-/// to accommodate sources like `OpenAPI` spec keys that use lowercase by convention.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    Get,
-    Post,
-    Put,
-    Delete,
-    Patch,
-}
+pub use http::Method as HttpMethod;
 
 /// Error returned when parsing an unrecognized HTTP method string.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("unknown HTTP method: {0}")]
 pub struct UnknownHttpMethod(pub String);
 
-impl FromStr for HttpMethod {
-    type Err = UnknownHttpMethod;
+fn parse_method_case_insensitive(s: &str) -> Result<Method, UnknownHttpMethod> {
+    Method::from_bytes(s.to_ascii_uppercase().as_bytes())
+        .map_err(|_| UnknownHttpMethod(s.to_string()))
+}
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "get" => Ok(Self::Get),
-            "post" => Ok(Self::Post),
-            "put" => Ok(Self::Put),
-            "delete" => Ok(Self::Delete),
-            "patch" => Ok(Self::Patch),
-            _ => Err(UnknownHttpMethod(s.to_string())),
-        }
+mod method_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use super::{Method, parse_method_case_insensitive};
+
+    pub fn serialize<S>(method: &Method, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(method.as_str())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Method, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        parse_method_case_insensitive(&value).map_err(serde::de::Error::custom)
     }
 }
 
-impl std::fmt::Display for HttpMethod {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Get => write!(f, "GET"),
-            Self::Post => write!(f, "POST"),
-            Self::Put => write!(f, "PUT"),
-            Self::Delete => write!(f, "DELETE"),
-            Self::Patch => write!(f, "PATCH"),
+mod request_headers_serde {
+    use std::str;
+
+    use http::{HeaderMap, HeaderName, HeaderValue};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(headers: &HeaderMap, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let pairs: Vec<(&str, &str)> = headers
+            .iter()
+            .map(|(name, value)| {
+                value
+                    .to_str()
+                    .map(|value| (name.as_str(), value))
+                    .map_err(serde::ser::Error::custom)
+            })
+            .collect::<Result<_, _>>()?;
+        pairs.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HeaderMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let pairs = Vec::<(String, String)>::deserialize(deserializer)?;
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            let name = HeaderName::from_bytes(name.as_bytes()).map_err(serde::de::Error::custom)?;
+            let value = HeaderValue::from_str(&value).map_err(serde::de::Error::custom)?;
+            headers.append(name, value);
         }
+        Ok(headers)
     }
 }
 
@@ -74,11 +97,15 @@ impl std::fmt::Display for HttpMethod {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApiRequest {
     /// HTTP method.
+    #[serde(with = "method_serde")]
     pub method: HttpMethod,
     /// Fully resolved URL path (path params substituted), e.g. `/documents/abc123`.
     pub path: String,
     /// Query parameters.
     pub query_params: Vec<(String, String)>,
+    /// Request headers supplied by the request builder.
+    #[serde(default, with = "request_headers_serde")]
+    pub headers: HeaderMap,
     /// Request body, if any.
     pub body: Option<RequestBody>,
     /// Content type for the request body.
@@ -146,9 +173,9 @@ impl RequestBody {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ApiResponse {
     /// HTTP status code.
-    pub status: u16,
-    /// Response headers as `(name, value)` pairs.
-    pub headers: Vec<(String, String)>,
+    pub status: StatusCode,
+    /// Response headers.
+    pub headers: HeaderMap,
     /// Response body bytes.
     pub body: ResponseBody,
 }
@@ -157,10 +184,7 @@ impl ApiResponse {
     /// Return the first response header value matching `name`, case-insensitively.
     #[must_use]
     pub fn header(&self, name: &str) -> Option<&str> {
-        self.headers
-            .iter()
-            .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
-            .map(|(_, value)| value.as_str())
+        self.headers.get(name).and_then(|value| value.to_str().ok())
     }
 
     /// Return the response `Content-Type` header, if present.
@@ -235,58 +259,52 @@ mod tests {
 
     #[test]
     fn http_method_from_str_lowercase() {
-        assert_eq!(HttpMethod::from_str("get"), Ok(HttpMethod::Get));
-        assert_eq!(HttpMethod::from_str("post"), Ok(HttpMethod::Post));
-        assert_eq!(HttpMethod::from_str("put"), Ok(HttpMethod::Put));
-        assert_eq!(HttpMethod::from_str("delete"), Ok(HttpMethod::Delete));
-        assert_eq!(HttpMethod::from_str("patch"), Ok(HttpMethod::Patch));
+        assert_eq!(parse_method_case_insensitive("get"), Ok(HttpMethod::GET));
+        assert_eq!(parse_method_case_insensitive("post"), Ok(HttpMethod::POST));
+        assert_eq!(parse_method_case_insensitive("put"), Ok(HttpMethod::PUT));
+        assert_eq!(
+            parse_method_case_insensitive("delete"),
+            Ok(HttpMethod::DELETE)
+        );
+        assert_eq!(
+            parse_method_case_insensitive("patch"),
+            Ok(HttpMethod::PATCH)
+        );
     }
 
     #[test]
     fn http_method_from_str_uppercase() {
-        assert_eq!(HttpMethod::from_str("GET"), Ok(HttpMethod::Get));
-        assert_eq!(HttpMethod::from_str("POST"), Ok(HttpMethod::Post));
+        assert_eq!(parse_method_case_insensitive("GET"), Ok(HttpMethod::GET));
+        assert_eq!(parse_method_case_insensitive("POST"), Ok(HttpMethod::POST));
     }
 
     #[test]
     fn http_method_from_str_mixed_case() {
-        assert_eq!(HttpMethod::from_str("Get"), Ok(HttpMethod::Get));
-        assert_eq!(HttpMethod::from_str("PoSt"), Ok(HttpMethod::Post));
+        assert_eq!(parse_method_case_insensitive("Get"), Ok(HttpMethod::GET));
+        assert_eq!(parse_method_case_insensitive("PoSt"), Ok(HttpMethod::POST));
     }
 
     #[test]
     fn http_method_from_str_unknown() {
-        assert!(HttpMethod::from_str("TRACE").is_err());
-        assert!(HttpMethod::from_str("").is_err());
+        assert!(parse_method_case_insensitive("").is_err());
     }
 
     #[test]
     fn http_method_display() {
-        assert_eq!(HttpMethod::Get.to_string(), "GET");
-        assert_eq!(HttpMethod::Post.to_string(), "POST");
-        assert_eq!(HttpMethod::Put.to_string(), "PUT");
-        assert_eq!(HttpMethod::Delete.to_string(), "DELETE");
-        assert_eq!(HttpMethod::Patch.to_string(), "PATCH");
-    }
-
-    #[test]
-    fn http_method_serializes_uppercase() {
-        let json = serde_json::to_string(&HttpMethod::Get).expect("should serialize");
-        assert_eq!(json, "\"GET\"");
-    }
-
-    #[test]
-    fn http_method_deserializes_uppercase() {
-        let method: HttpMethod = serde_json::from_str("\"POST\"").expect("should deserialize");
-        assert_eq!(method, HttpMethod::Post);
+        assert_eq!(HttpMethod::GET.to_string(), "GET");
+        assert_eq!(HttpMethod::POST.to_string(), "POST");
+        assert_eq!(HttpMethod::PUT.to_string(), "PUT");
+        assert_eq!(HttpMethod::DELETE.to_string(), "DELETE");
+        assert_eq!(HttpMethod::PATCH.to_string(), "PATCH");
     }
 
     #[test]
     fn api_request_serializes() {
         let req = ApiRequest {
-            method: HttpMethod::Get,
+            method: HttpMethod::GET,
             path: "/documents/abc123".to_string(),
             query_params: vec![("limit".to_string(), "10".to_string())],
+            headers: HeaderMap::new(),
             body: None,
             content_type: None,
         };
@@ -298,9 +316,10 @@ mod tests {
     #[test]
     fn api_request_with_json_body_serializes() {
         let req = ApiRequest {
-            method: HttpMethod::Post,
+            method: HttpMethod::POST,
             path: "/documents".to_string(),
             query_params: vec![],
+            headers: HeaderMap::new(),
             body: Some(RequestBody::Json(serde_json::json!({"name": "test"}))),
             content_type: Some("application/json".to_string()),
         };
@@ -338,8 +357,11 @@ mod tests {
     #[test]
     fn api_response_header_lookup_is_case_insensitive() {
         let response = ApiResponse {
-            status: 200,
-            headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+            status: StatusCode::OK,
+            headers: HeaderMap::from_iter([(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("application/json"),
+            )]),
             body: ResponseBody::from("{}"),
         };
 

--- a/crates/onshape-client-io/Cargo.toml
+++ b/crates/onshape-client-io/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings"]
 [dependencies]
 oauth2.workspace = true
 onshape-client-core.workspace = true
+http.workspace = true
 reqwest.workspace = true
 secrecy.workspace = true
 serde_json.workspace = true

--- a/crates/onshape-client-io/src/lib.rs
+++ b/crates/onshape-client-io/src/lib.rs
@@ -13,13 +13,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use http::header::{ACCEPT, AUTHORIZATION};
 use oauth2::AccessToken;
 use onshape_client_core::auth::{
     Credentials, basic_authorization_header_value, bearer_authorization_header_value,
 };
-use onshape_client_core::request::{
-    ApiRequest, ApiResponse, HttpMethod, RequestBody, ResponseBody,
-};
+use onshape_client_core::request::{ApiRequest, ApiResponse, RequestBody, ResponseBody};
 use reqwest::Client;
 use secrecy::ExposeSecret;
 
@@ -195,13 +194,19 @@ impl OnshapeClient {
             }
         };
 
-        let method = to_reqwest_method(request.method);
+        let mut headers = request.headers.clone();
+        headers.remove(AUTHORIZATION);
+        let has_accept = headers.contains_key(ACCEPT);
 
         let mut builder = self
             .http
-            .request(method, &url)
-            .header("Authorization", auth_header.expose_secret())
-            .header("Accept", "application/json");
+            .request(request.method.clone(), &url)
+            .headers(headers)
+            .header(AUTHORIZATION, auth_header.expose_secret());
+
+        if !has_accept {
+            builder = builder.header(ACCEPT, "application/json");
+        }
 
         // Add query parameters.
         if !request.query_params.is_empty() {
@@ -258,8 +263,8 @@ impl OnshapeClient {
             .await
             .map_err(|e| ClientError::from_reqwest(&e, self.timeout))?;
 
-        let status = response.status().as_u16();
-        let headers = response_headers_to_pairs(response.headers());
+        let status = response.status();
+        let headers = response.headers().clone();
         let body = response
             .bytes()
             .await
@@ -273,33 +278,6 @@ impl OnshapeClient {
             body: ResponseBody::from(body.to_vec()),
         })
     }
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/// Convert our sans-IO `HttpMethod` to a `reqwest::Method`.
-const fn to_reqwest_method(method: HttpMethod) -> reqwest::Method {
-    match method {
-        HttpMethod::Get => reqwest::Method::GET,
-        HttpMethod::Post => reqwest::Method::POST,
-        HttpMethod::Put => reqwest::Method::PUT,
-        HttpMethod::Delete => reqwest::Method::DELETE,
-        HttpMethod::Patch => reqwest::Method::PATCH,
-    }
-}
-
-fn response_headers_to_pairs(headers: &reqwest::header::HeaderMap) -> Vec<(String, String)> {
-    headers
-        .iter()
-        .map(|(name, value)| {
-            (
-                name.as_str().to_string(),
-                String::from_utf8_lossy(value.as_bytes()).into_owned(),
-            )
-        })
-        .collect()
 }
 
 // ============================================================================
@@ -393,36 +371,6 @@ mod tests {
         let _cloned = client.clone();
     }
 
-    #[test]
-    fn to_reqwest_method_maps_correctly() {
-        assert_eq!(to_reqwest_method(HttpMethod::Get), reqwest::Method::GET);
-        assert_eq!(to_reqwest_method(HttpMethod::Post), reqwest::Method::POST);
-        assert_eq!(to_reqwest_method(HttpMethod::Put), reqwest::Method::PUT);
-        assert_eq!(
-            to_reqwest_method(HttpMethod::Delete),
-            reqwest::Method::DELETE
-        );
-        assert_eq!(to_reqwest_method(HttpMethod::Patch), reqwest::Method::PATCH);
-    }
-
-    #[test]
-    fn response_headers_to_pairs_preserves_header_values() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            "Content-Type",
-            "application/octet-stream".parse().expect("valid header"),
-        );
-        headers.insert("X-Test", "value".parse().expect("valid header"));
-
-        let pairs = response_headers_to_pairs(&headers);
-
-        assert!(pairs.contains(&(
-            "content-type".to_string(),
-            "application/octet-stream".to_string(),
-        )));
-        assert!(pairs.contains(&("x-test".to_string(), "value".to_string())));
-    }
-
     #[tokio::test]
     async fn execute_returns_binary_body_and_headers() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("should bind test server");
@@ -460,9 +408,10 @@ mod tests {
         })
         .expect("should create client");
         let request = ApiRequest {
-            method: HttpMethod::Get,
+            method: http::Method::GET,
             path: "/binary".to_string(),
             query_params: Vec::new(),
+            headers: http::HeaderMap::new(),
             body: None,
             content_type: None,
         };
@@ -473,10 +422,128 @@ mod tests {
             .expect("request should succeed");
         server.join().expect("server thread should finish");
 
-        assert_eq!(response.status, 200);
+        assert_eq!(response.status, http::StatusCode::OK);
         assert_eq!(response.content_type(), Some("application/octet-stream"));
         assert_eq!(response.header("x-test"), Some("binary"));
         assert_eq!(response.body.as_bytes(), &[0, 159, 146, 150]);
         assert!(response.body.text().is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_preserves_explicit_accept_header() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("should bind test server");
+        let address = listener
+            .local_addr()
+            .expect("should get test server address");
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("should accept request");
+            let mut buffer = [0_u8; 4096];
+            let received = stream.read(&mut buffer).expect("should read request");
+            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            assert!(
+                request.contains("accept: application/octet-stream"),
+                "request should preserve explicit Accept header, got: {request}"
+            );
+            assert!(
+                !request.contains("accept: application/json"),
+                "request should not add default JSON Accept header, got: {request}"
+            );
+
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("should write response");
+        });
+
+        let client = OnshapeClient::new(ClientConfig {
+            base_url: format!("http://{address}"),
+            auth: ClientAuthConfig::Basic {
+                credentials: test_credentials(),
+            },
+            timeout: Some(Duration::from_secs(10)),
+        })
+        .expect("should create client");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            ACCEPT,
+            http::HeaderValue::from_static("application/octet-stream"),
+        );
+        let request = ApiRequest {
+            method: http::Method::GET,
+            path: "/binary".to_string(),
+            query_params: Vec::new(),
+            headers,
+            body: None,
+            content_type: None,
+        };
+
+        let response = client
+            .execute(&request)
+            .await
+            .expect("request should succeed");
+        server.join().expect("server thread should finish");
+
+        assert_eq!(response.status, http::StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn execute_ignores_caller_authorization_header() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("should bind test server");
+        let address = listener
+            .local_addr()
+            .expect("should get test server address");
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("should accept request");
+            let mut buffer = [0_u8; 4096];
+            let received = stream.read(&mut buffer).expect("should read request");
+            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            assert!(
+                request.contains("authorization: basic"),
+                "request should include executor-owned auth, got: {request}"
+            );
+            assert!(
+                !request.contains("authorization: bearer caller-token"),
+                "request should ignore caller auth header, got: {request}"
+            );
+
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("should write response");
+        });
+
+        let client = OnshapeClient::new(ClientConfig {
+            base_url: format!("http://{address}"),
+            auth: ClientAuthConfig::Basic {
+                credentials: test_credentials(),
+            },
+            timeout: Some(Duration::from_secs(10)),
+        })
+        .expect("should create client");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            http::HeaderValue::from_static("Bearer caller-token"),
+        );
+        let request = ApiRequest {
+            method: http::Method::GET,
+            path: "/auth".to_string(),
+            query_params: Vec::new(),
+            headers,
+            body: None,
+            content_type: None,
+        };
+
+        let response = client
+            .execute(&request)
+            .await
+            .expect("request should succeed");
+        server.join().expect("server thread should finish");
+
+        assert_eq!(response.status, http::StatusCode::NO_CONTENT);
     }
 }

--- a/crates/onshape-mcp-core/Cargo.toml
+++ b/crates/onshape-mcp-core/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+http.workspace = true
 toml.workspace = true
 
 [lints]

--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -151,7 +151,7 @@ pub enum ToolEffect {
     /// the continuation and an [`IoResult::ApiResponse`].
     ApiRequest {
         /// The HTTP request to execute.
-        request: ApiRequest,
+        request: Box<ApiRequest>,
         /// What to do with the response.
         continuation: Continuation,
     },
@@ -557,7 +557,7 @@ fn resume_inject_files(
     }
 
     ToolEffect::ApiRequest {
-        request,
+        request: Box::new(request),
         continuation: Continuation::FormatApiResponse,
     }
 }
@@ -1381,7 +1381,7 @@ fn call_auth_status(
     };
 
     ToolEffect::ApiRequest {
-        request,
+        request: Box::new(request),
         continuation: Continuation::ProcessAuthValidation {
             resolved_auth: resolved_auth.clone(),
         },
@@ -1554,7 +1554,7 @@ fn call_api_call(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -> 
     // the request as an ApiRequest effect.
     if input.file_refs.is_empty() {
         ToolEffect::ApiRequest {
-            request,
+            request: Box::new(request),
             continuation: Continuation::FormatApiResponse,
         }
     } else {
@@ -1934,7 +1934,7 @@ fn call_screenshot(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -
     // --- Return the two-phase effect: API call, then file writes ---
 
     ToolEffect::ApiRequest {
-        request,
+        request: Box::new(request),
         continuation: Continuation::ProcessScreenshotResponse {
             output_path,
             label,
@@ -2164,7 +2164,7 @@ mod tests {
             ToolEffect::ApiRequest {
                 request,
                 continuation,
-            } => (request, continuation),
+            } => (*request, continuation),
             other => panic!("expected ApiRequest, got {other:?}"),
         }
     }
@@ -2788,7 +2788,7 @@ mod tests {
             Some(&spec),
         );
         let (request, _continuation) = assert_api_request(result);
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(request.path, "/documents");
         assert!(
             request.body.is_some(),
@@ -4469,9 +4469,10 @@ mod tests {
     fn json_request_for_injection(body: Value) -> ApiRequest {
         use onshape_client_core::request::{HttpMethod, RequestBody};
         ApiRequest {
-            method: HttpMethod::Post,
+            method: HttpMethod::POST,
             path: "/test".to_string(),
             query_params: vec![],
+            headers: http::HeaderMap::default(),
             body: Some(RequestBody::Json(body)),
             content_type: Some("application/json".to_string()),
         }
@@ -4583,9 +4584,10 @@ mod tests {
     fn multipart_request_for_injection(text_fields: Vec<(String, String)>) -> ApiRequest {
         use onshape_client_core::request::{HttpMethod, MultipartBody, RequestBody};
         ApiRequest {
-            method: HttpMethod::Post,
+            method: HttpMethod::POST,
             path: "/upload".to_string(),
             query_params: vec![],
+            headers: http::HeaderMap::default(),
             body: Some(RequestBody::Multipart(MultipartBody {
                 text_fields,
                 binary_fields: vec![],
@@ -4728,9 +4730,10 @@ mod tests {
     fn resume_inject_no_body_returns_error() {
         use onshape_client_core::request::HttpMethod;
         let request = ApiRequest {
-            method: HttpMethod::Get,
+            method: HttpMethod::GET,
             path: "/test".to_string(),
             query_params: vec![],
+            headers: http::HeaderMap::default(),
             body: None,
             content_type: None,
         };

--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -141,6 +141,7 @@ pub enum LoginMode {
 ///
 /// All variants are plain data — no closures — so `ToolEffect` is
 /// inspectable, `Debug`-printable, and testable.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ToolEffect {
     /// Tool completed — no further I/O needed.
@@ -151,7 +152,7 @@ pub enum ToolEffect {
     /// the continuation and an [`IoResult::ApiResponse`].
     ApiRequest {
         /// The HTTP request to execute.
-        request: Box<ApiRequest>,
+        request: ApiRequest,
         /// What to do with the response.
         continuation: Continuation,
     },
@@ -557,7 +558,7 @@ fn resume_inject_files(
     }
 
     ToolEffect::ApiRequest {
-        request: Box::new(request),
+        request,
         continuation: Continuation::FormatApiResponse,
     }
 }
@@ -1381,7 +1382,7 @@ fn call_auth_status(
     };
 
     ToolEffect::ApiRequest {
-        request: Box::new(request),
+        request,
         continuation: Continuation::ProcessAuthValidation {
             resolved_auth: resolved_auth.clone(),
         },
@@ -1554,7 +1555,7 @@ fn call_api_call(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -> 
     // the request as an ApiRequest effect.
     if input.file_refs.is_empty() {
         ToolEffect::ApiRequest {
-            request: Box::new(request),
+            request,
             continuation: Continuation::FormatApiResponse,
         }
     } else {
@@ -1934,7 +1935,7 @@ fn call_screenshot(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -
     // --- Return the two-phase effect: API call, then file writes ---
 
     ToolEffect::ApiRequest {
-        request: Box::new(request),
+        request,
         continuation: Continuation::ProcessScreenshotResponse {
             output_path,
             label,
@@ -2163,7 +2164,7 @@ mod tests {
             ToolEffect::ApiRequest {
                 request,
                 continuation,
-            } => (*request, continuation),
+            } => (request, continuation),
             other => panic!("expected ApiRequest, got {other:?}"),
         }
     }

--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -2019,7 +2019,6 @@ fn parse_arguments<T: serde::de::DeserializeOwned>(
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use onshape_client_core::request::HttpMethod;
 
     use crate::ValidationState;
 
@@ -2788,7 +2787,7 @@ mod tests {
             Some(&spec),
         );
         let (request, _continuation) = assert_api_request(result);
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, http::Method::GET);
         assert_eq!(request.path, "/documents");
         assert!(
             request.body.is_some(),
@@ -4467,9 +4466,9 @@ mod tests {
 
     /// Build a minimal `ApiRequest` with a JSON body for injection tests.
     fn json_request_for_injection(body: Value) -> ApiRequest {
-        use onshape_client_core::request::{HttpMethod, RequestBody};
+        use onshape_client_core::request::RequestBody;
         ApiRequest {
-            method: HttpMethod::POST,
+            method: http::Method::POST,
             path: "/test".to_string(),
             query_params: vec![],
             headers: http::HeaderMap::default(),
@@ -4582,9 +4581,9 @@ mod tests {
 
     /// Build a minimal `ApiRequest` with a multipart body for injection tests.
     fn multipart_request_for_injection(text_fields: Vec<(String, String)>) -> ApiRequest {
-        use onshape_client_core::request::{HttpMethod, MultipartBody, RequestBody};
+        use onshape_client_core::request::{MultipartBody, RequestBody};
         ApiRequest {
-            method: HttpMethod::POST,
+            method: http::Method::POST,
             path: "/upload".to_string(),
             query_params: vec![],
             headers: http::HeaderMap::default(),
@@ -4728,9 +4727,8 @@ mod tests {
 
     #[test]
     fn resume_inject_no_body_returns_error() {
-        use onshape_client_core::request::HttpMethod;
         let request = ApiRequest {
-            method: HttpMethod::GET,
+            method: http::Method::GET,
             path: "/test".to_string(),
             query_params: vec![],
             headers: http::HeaderMap::default(),

--- a/crates/onshape-mcp-io/src/lib.rs
+++ b/crates/onshape-mcp-io/src/lib.rs
@@ -729,10 +729,22 @@ struct RawResponse {
 
 fn raw_response_from_api_response(response: ApiResponse) -> RawResponse {
     RawResponse {
-        status: response.status,
-        headers: response.headers,
+        status: response.status.as_u16(),
+        headers: header_map_to_pairs(&response.headers),
         body: response.body.bytes,
     }
+}
+
+fn header_map_to_pairs(headers: &http::HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            )
+        })
+        .collect()
 }
 
 fn resume_with_raw_response(
@@ -848,7 +860,7 @@ async fn execute_oauth_inner(
     if let Ok(ref response) = result
         && oauth
             .session
-            .post_execute_action(response.status, refreshed)
+            .post_execute_action(response.status.as_u16(), refreshed)
             == PostExecuteAction::RefreshAndRetry
     {
         if let Err(e) = try_refresh(oauth).await {
@@ -1871,8 +1883,11 @@ mod tests {
     #[test]
     fn raw_response_from_api_response_preserves_bytes_and_headers() {
         let response = ApiResponse {
-            status: 200,
-            headers: vec![("Content-Type".to_string(), "text/plain".to_string())],
+            status: http::StatusCode::OK,
+            headers: http::HeaderMap::from_iter([(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("text/plain"),
+            )]),
             body: ResponseBody::from("ok"),
         };
 
@@ -1881,7 +1896,7 @@ mod tests {
         assert_eq!(raw.status, 200);
         assert_eq!(
             raw.headers,
-            vec![("Content-Type".to_string(), "text/plain".to_string())]
+            vec![("content-type".to_string(), "text/plain".to_string())]
         );
         assert_eq!(raw.body, b"ok");
     }
@@ -1889,11 +1904,11 @@ mod tests {
     #[test]
     fn resume_with_raw_response_passes_invalid_utf8_to_continuation() {
         let response = ApiResponse {
-            status: 200,
-            headers: vec![(
-                "content-type".to_string(),
-                "application/octet-stream".to_string(),
-            )],
+            status: http::StatusCode::OK,
+            headers: http::HeaderMap::from_iter([(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("application/octet-stream"),
+            )]),
             body: ResponseBody::from(vec![0xff]),
         };
 

--- a/crates/onshape-openapi/Cargo.toml
+++ b/crates/onshape-openapi/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 base64.workspace = true
+http.workspace = true
 onshape-client-core.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 
 use base64::Engine;
+use http::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -51,7 +52,7 @@ pub struct EndpointSummary {
     /// The operation ID (unique identifier for this endpoint).
     pub operation_id: String,
     /// HTTP method.
-    pub method: HttpMethod,
+    pub method: String,
     /// URL path template (e.g., `/documents/{did}`).
     pub path: String,
     /// One-line description of the endpoint.
@@ -96,7 +97,7 @@ pub struct EndpointDetail {
     /// The operation ID.
     pub operation_id: String,
     /// HTTP method.
-    pub method: HttpMethod,
+    pub method: String,
     /// URL path template.
     pub path: String,
     /// Full description of the endpoint.
@@ -283,7 +284,8 @@ impl OpenApiSpec {
                 continue;
             };
             for (method_str, detail) in methods {
-                let Ok(method) = method_str.parse::<HttpMethod>() else {
+                let Ok(method) = HttpMethod::from_bytes(method_str.to_ascii_uppercase().as_bytes())
+                else {
                     continue;
                 };
                 let Some(operation_id) = detail.get("operationId").and_then(Value::as_str) else {
@@ -332,7 +334,7 @@ impl OpenApiSpec {
         let method_filter = filters
             .method
             .as_deref()
-            .and_then(|s| s.parse::<HttpMethod>().ok());
+            .and_then(|s| HttpMethod::from_bytes(s.to_ascii_uppercase().as_bytes()).ok());
 
         let tag_filter = filters.tag.as_deref().map(str::to_lowercase);
 
@@ -365,7 +367,7 @@ impl OpenApiSpec {
 
             results.push(EndpointSummary {
                 operation_id: ep.operation_id.clone(),
-                method: ep.method,
+                method: ep.method.to_string(),
                 path: ep.path.clone(),
                 description: if ep.summary.is_empty() {
                     Self::truncate_description(&ep.description, 120)
@@ -394,7 +396,7 @@ impl OpenApiSpec {
 
         Ok(EndpointDetail {
             operation_id: ep.operation_id.clone(),
-            method: ep.method,
+            method: ep.method.to_string(),
             path: ep.path.clone(),
             description: if ep.description.is_empty() {
                 ep.summary.clone()
@@ -481,7 +483,7 @@ impl OpenApiSpec {
             if param.location == ParameterLocation::Header && param.required {
                 return Err(OpenApiError::InvalidParams {
                     reason: format!(
-                        "required header parameter `{}` is unsupported because API requests do not model request headers yet",
+                        "required header parameter `{}` is unsupported because dynamic request building does not accept header parameter values yet",
                         param.name
                     ),
                 });
@@ -513,9 +515,10 @@ impl OpenApiSpec {
         };
 
         Ok(ApiRequest {
-            method: ep.method,
+            method: ep.method.clone(),
             path: resolved_path,
             query_params: query_params_vec,
+            headers: HeaderMap::new(),
             body: request_body,
             content_type: ep.request_body_content_type.clone(),
         })
@@ -1564,7 +1567,7 @@ mod tests {
         );
         // Only GET operations that match "document"
         assert_eq!(results.len(), 2);
-        assert!(results.iter().all(|r| r.method == HttpMethod::Get));
+        assert!(results.iter().all(|r| r.method == "GET"));
     }
 
     #[test]
@@ -1573,7 +1576,7 @@ mod tests {
         let detail = spec.explain("getDocuments").expect("should find");
 
         assert_eq!(detail.operation_id, "getDocuments");
-        assert_eq!(detail.method, HttpMethod::Get);
+        assert_eq!(detail.method, "GET");
         assert_eq!(detail.path, "/documents");
         assert_eq!(detail.parameters.len(), 2);
         assert!(!detail.has_request_body);
@@ -1610,7 +1613,7 @@ mod tests {
             .build_request("getDocument", &path_params, &HashMap::new(), None)
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(request.path, "/documents/abc%2F123%20model");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -1636,7 +1639,7 @@ mod tests {
             .build_request("getDocuments", &HashMap::new(), &query_params, None)
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(request.method, HttpMethod::GET);
         assert_eq!(request.path, "/documents");
         assert_eq!(request.query_params.len(), 2);
 
@@ -1730,6 +1733,10 @@ mod tests {
                     reason.contains("required header parameter `If-Match` is unsupported"),
                     "error should mention unsupported required header, got: {reason}"
                 );
+                assert!(
+                    reason.contains("does not accept header parameter values yet"),
+                    "error should explain dynamic request input limitation, got: {reason}"
+                );
             }
             other => panic!("expected InvalidParams, got {other:?}"),
         }
@@ -1749,7 +1756,7 @@ mod tests {
             )
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::Post);
+        assert_eq!(request.method, HttpMethod::POST);
         assert!(
             matches!(request.body, Some(RequestBody::Json(_))),
             "JSON endpoint should produce RequestBody::Json"

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -6,12 +6,12 @@
 use std::collections::{HashMap, HashSet};
 
 use base64::Engine;
-use http::HeaderMap;
+use http::{HeaderMap, Method};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub use onshape_client_core::request::{ApiRequest, HttpMethod};
+pub use onshape_client_core::request::ApiRequest;
 use onshape_client_core::request::{BinaryField, MultipartBody, RequestBody};
 
 // ============================================================================
@@ -138,7 +138,7 @@ pub struct SearchFilters {
 #[derive(Clone, Debug)]
 struct ParsedEndpoint {
     operation_id: String,
-    method: HttpMethod,
+    method: Method,
     path: String,
     summary: String,
     description: String,
@@ -284,7 +284,7 @@ impl OpenApiSpec {
                 continue;
             };
             for (method_str, detail) in methods {
-                let Ok(method) = HttpMethod::from_bytes(method_str.to_ascii_uppercase().as_bytes())
+                let Ok(method) = Method::from_bytes(method_str.to_ascii_uppercase().as_bytes())
                 else {
                     continue;
                 };
@@ -334,7 +334,7 @@ impl OpenApiSpec {
         let method_filter = filters
             .method
             .as_deref()
-            .and_then(|s| HttpMethod::from_bytes(s.to_ascii_uppercase().as_bytes()).ok());
+            .and_then(|s| Method::from_bytes(s.to_ascii_uppercase().as_bytes()).ok());
 
         let tag_filter = filters.tag.as_deref().map(str::to_lowercase);
 
@@ -862,7 +862,7 @@ impl OpenApiSpec {
 
     fn parse_endpoint(
         operation_id: &str,
-        method: HttpMethod,
+        method: Method,
         path: &str,
         detail: &Value,
         components: &HashMap<String, Value>,
@@ -1613,7 +1613,7 @@ mod tests {
             .build_request("getDocument", &path_params, &HashMap::new(), None)
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, Method::GET);
         assert_eq!(request.path, "/documents/abc%2F123%20model");
         assert!(request.query_params.is_empty());
         assert!(request.body.is_none());
@@ -1639,7 +1639,7 @@ mod tests {
             .build_request("getDocuments", &HashMap::new(), &query_params, None)
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::GET);
+        assert_eq!(request.method, Method::GET);
         assert_eq!(request.path, "/documents");
         assert_eq!(request.query_params.len(), 2);
 
@@ -1756,7 +1756,7 @@ mod tests {
             )
             .expect("should build");
 
-        assert_eq!(request.method, HttpMethod::POST);
+        assert_eq!(request.method, Method::POST);
         assert!(
             matches!(request.body, Some(RequestBody::Json(_))),
             "JSON endpoint should produce RequestBody::Json"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,7 +10,7 @@
 - [Architecture](project/architecture.md)
 - [Data Flow](project/data-flow.md)
 - [Common Onshape Client Extraction Plan](project/common-onshape-client-plan.md)
-- [HTTP Types Alignment Plan](project/http-types-plan.md)
+- [HTTP Types Alignment Decision](project/http-types-plan.md)
 - [Requirements](project/requirements.md)
 
 # Features

--- a/docs/src/project/common-onshape-client-plan.md
+++ b/docs/src/project/common-onshape-client-plan.md
@@ -46,15 +46,13 @@ what decision or dependency is missing.
 - Keep `ApiRequest` relative to an application-provided Onshape API base URL.
   Do not allow arbitrary absolute URLs in the normal authenticated API request
   type.
-- Do not add request header or `accept` fields in the first response refactor.
-  Preserve the existing JSON-oriented request behavior until a concrete need is
-  proven.
-- Until request headers are intentionally modeled, OpenAPI request building must
+- Request headers are modeled with `http::HeaderMap`; preserve the existing
+  JSON-oriented default `Accept` behavior until a request explicitly overrides it.
+- Until dynamic OpenAPI request building accepts header parameter inputs, it must
   not silently drop header parameters. Required header parameters should make
   request construction fail with a clear unsupported-parameter error.
-- Represent response headers as plain `Vec<(String, String)>` for the first
-  response refactor, with helper methods for common lookups. Revisit standard
-  `http` crate protocol types as a separate planned effort.
+- Represent response headers as `http::HeaderMap` so common callers can inspect
+  standard HTTP metadata without coupling to a network framework.
 - Convert buffered response bytes to text only at the MCP boundary. Existing MCP
   text/JSON continuations should use strict UTF-8 decoding; invalid UTF-8 should
   become an explicit error instead of lossy text.
@@ -235,8 +233,8 @@ Target shape:
 
 ```rust
 pub struct ApiResponse {
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
+    pub status: http::StatusCode,
+    pub headers: http::HeaderMap,
     pub body: ResponseBody,
 }
 
@@ -246,25 +244,20 @@ pub struct ResponseBody {
 ```
 
 Add convenience helpers such as `as_bytes()`, `text()`, `text_lossy()`, and
-`content_type()` as needed. Use plain `Vec<(String, String)>` response headers
-for this step; defer possible `http::HeaderMap` adoption to the separate HTTP
-types alignment effort. Keep HTTP error statuses as successful transport
+`content_type()` as needed. Keep HTTP error statuses as successful transport
 responses; callers decide how to interpret them.
 
 ### 2. Update the Reqwest Executor
 
 - Change response reading from `.text().await` to `.bytes().await`.
-- Capture response headers as neutral `(String, String)` pairs, not
-  `reqwest::HeaderMap`.
-- Preserve existing request behavior, including the current JSON-oriented
-  `Accept` header.
-- Do not add generic request headers or an `accept` field in this first response
-  refactor.
+- Capture response headers as `http::HeaderMap`.
+- Preserve existing JSON-oriented `Accept` behavior unless the request includes
+  an explicit `Accept` header.
+- Model request headers as `http::HeaderMap` while keeping authentication
+  executor-owned.
 - Dynamic OpenAPI request building should reject endpoints with required header
-  parameters for now, because the common request type cannot represent them yet.
-  Do not silently omit required headers.
-- If future export artifact downloads require different `Accept` behavior, add
-  that as a focused follow-up once the concrete endpoint behavior is known.
+  parameters for now, because its public input shape cannot accept separate
+  header parameter values yet. Do not silently omit required headers.
 
 ### 3. Adapt MCP at the Boundary
 
@@ -347,7 +340,8 @@ in shared decisions such as proactive refresh margins and retry-on-401 behavior.
 Ensure coverage exists for:
 
 - path and query parameter substitution.
-- required header parameters are rejected while request headers are unsupported.
+- required header parameters are rejected until dynamic OpenAPI request building
+  has a header-parameter input map.
 - JSON body request building.
 - multipart binary and text body building.
 - schema lookup with `allOf`.
@@ -393,8 +387,8 @@ Implemented focused first helper set:
   external data IDs needed to download exported artifacts.
 - Request builders cite the `OpenAPI` operation IDs they implement and have
   golden tests for method, path, body, and content type construction.
-- Download media negotiation remains a separate request-header/`Accept` follow-up;
-  the common request model still does not carry request headers.
+- Endpoint-specific download media negotiation remains a separate `Accept`
+  follow-up; the common request model can now carry request headers.
 
 Place these initially under `onshape-client-core::endpoints::*`, separate from
 low-level `request`, `response`, `auth`, and `oauth` modules. Helpers must build

--- a/docs/src/project/http-types-plan.md
+++ b/docs/src/project/http-types-plan.md
@@ -1,12 +1,9 @@
-# HTTP Types Alignment Plan
+# HTTP Types Alignment Decision
 
 ## Intent
 
-Evaluate and, where appropriate, adopt the Rust `http` crate's standard protocol
-types in common Onshape client boundaries.
-
-This should be a distinct future refactor, not bundled with the first binary
-response or crate-boundary cleanup work.
+Record the adopted use of the Rust `http` crate's standard protocol types in
+common Onshape client boundaries.
 
 ## Motivation
 
@@ -16,42 +13,19 @@ The `http` crate provides widely used sans-IO protocol types such as
 it is already a common dependency across `reqwest`, `axum`, `hyper`, and
 `tower`-based code.
 
-Using these types may reduce custom HTTP modeling and improve interoperability
+Using these types reduces custom HTTP modeling and improves interoperability
 without coupling common crates to a specific IO implementation.
 
-## Scope
+## Adopted Scope
 
-Research later whether `http` types should replace or supplement local types in:
+Use standard `http` protocol types in:
 
 - response headers.
 - request headers.
 - status codes.
 - methods.
-- URLs/URIs, if useful.
 
-Keep this separate from application behavior, token refresh orchestration, MCP
-tool logic, and export-service-specific concerns.
-
-## Initial Preference
-
-Prefer adopting `http` types where they improve correctness and interop without
-making common APIs awkward to serialize, test, or use as plain sans-IO data.
-
-Do not make this change opportunistically during unrelated refactors. Revisit it
-with focused research and implementation when the common response/request model
-is otherwise stable.
-
-## Issue 487 Experiment
-
-Issue #487 implemented a focused switch to standard `http` protocol types at the
-common client boundary:
-
-- `ApiRequest.method` is `http::Method`.
-- `ApiRequest.headers` is `http::HeaderMap`.
-- `ApiResponse.status` is `http::StatusCode`.
-- `ApiResponse.headers` is `http::HeaderMap`.
-
-The experiment intentionally keeps these local/plain-data choices:
+Keep these local/plain-data choices:
 
 - `ApiRequest.path` remains a relative Onshape API path `String`; applications
   still own the base URL.
@@ -62,7 +36,20 @@ The experiment intentionally keeps these local/plain-data choices:
 - MCP tool continuations still receive plain `u16`, header pairs, and bytes; the
   richer common response is converted at the MCP I/O boundary.
 
-Observed tradeoffs:
+Keep this separate from application behavior, token refresh orchestration, MCP
+tool logic, and export-service-specific concerns.
+
+## Decision
+
+Issue #487 adopted a focused switch to standard `http` protocol types at the
+common client boundary:
+
+- `ApiRequest.method` is `http::Method`.
+- `ApiRequest.headers` is `http::HeaderMap`.
+- `ApiResponse.status` is `http::StatusCode`.
+- `ApiResponse.headers` is `http::HeaderMap`.
+
+## Tradeoffs
 
 - `http::Method` removes the local method enum and interops directly with
   `reqwest`, but OpenAPI lowercase method keys require explicit normalization.
@@ -71,10 +58,13 @@ Observed tradeoffs:
 - The `http` crate does not expose serde/schema implementations for these types,
   so `ApiRequest` needs custom serde helpers and OpenAPI search/explain DTOs keep
   method values as strings for MCP schemas.
-- Request headers are now representable and `onshape-client-io` applies them
-  before setting authentication. Caller-supplied `Authorization` is overwritten
-  by executor-owned auth, and `Accept: application/json` remains the default when
-  no explicit `Accept` is present.
+- Request headers are representable and `onshape-client-io` applies them before
+  setting authentication. Caller-supplied `Authorization` is overwritten by
+  executor-owned auth, and `Accept: application/json` remains the default when no
+  explicit `Accept` is present.
 - Dynamic OpenAPI request construction still rejects required header parameters
   because its public input shape has no separate header-parameter map yet; that
   remains part of the request-header/`Accept` follow-up.
+
+Do not revisit this decision without a concrete problem from real common-client
+or export-service usage.

--- a/docs/src/project/http-types-plan.md
+++ b/docs/src/project/http-types-plan.md
@@ -40,3 +40,41 @@ making common APIs awkward to serialize, test, or use as plain sans-IO data.
 Do not make this change opportunistically during unrelated refactors. Revisit it
 with focused research and implementation when the common response/request model
 is otherwise stable.
+
+## Issue 487 Experiment
+
+Issue #487 implemented a focused switch to standard `http` protocol types at the
+common client boundary:
+
+- `ApiRequest.method` is `http::Method`.
+- `ApiRequest.headers` is `http::HeaderMap`.
+- `ApiResponse.status` is `http::StatusCode`.
+- `ApiResponse.headers` is `http::HeaderMap`.
+
+The experiment intentionally keeps these local/plain-data choices:
+
+- `ApiRequest.path` remains a relative Onshape API path `String`; applications
+  still own the base URL.
+- `ApiRequest.query_params` remains `Vec<(String, String)>` for deterministic
+  construction and serialization.
+- The common client does not wrap requests/responses in `http::Request` or
+  `http::Response`.
+- MCP tool continuations still receive plain `u16`, header pairs, and bytes; the
+  richer common response is converted at the MCP I/O boundary.
+
+Observed tradeoffs:
+
+- `http::Method` removes the local method enum and interops directly with
+  `reqwest`, but OpenAPI lowercase method keys require explicit normalization.
+- `http::HeaderMap` gives case-insensitive lookup, duplicate-header support, and
+  non-UTF-8 value preservation for responses.
+- The `http` crate does not expose serde/schema implementations for these types,
+  so `ApiRequest` needs custom serde helpers and OpenAPI search/explain DTOs keep
+  method values as strings for MCP schemas.
+- Request headers are now representable and `onshape-client-io` applies them
+  before setting authentication. Caller-supplied `Authorization` is overwritten
+  by executor-owned auth, and `Accept: application/json` remains the default when
+  no explicit `Accept` is present.
+- Dynamic OpenAPI request construction still rejects required header parameters
+  because its public input shape has no separate header-parameter map yet; that
+  remains part of the request-header/`Accept` follow-up.

--- a/docs/src/project/index.md
+++ b/docs/src/project/index.md
@@ -9,7 +9,7 @@ A Rust-based MCP (Model Context Protocol) server for Onshape integration. The pr
 - [Principles](principles.md) — Sans-IO philosophy, testability goals, dependencies policy
 - [Architecture](architecture.md) — Layer design, crate structure, workspace layout
 - [Common Onshape Client Extraction Plan](common-onshape-client-plan.md) — Incremental plan for neutral common client crates
-- [HTTP Types Alignment Plan](http-types-plan.md) — Future evaluation of standard `http` crate protocol types
+- [HTTP Types Alignment Decision](http-types-plan.md) — Adopted use of standard `http` crate protocol types
 - [Requirements](requirements.md) — Platform support, technology choices, toolchain
 
 ### Features


### PR DESCRIPTION
## Summary
- switch common client request/response boundaries to http::Method, http::StatusCode, and http::HeaderMap
- add request header support with default JSON Accept preserved and executor-owned Authorization protected
- document the tradeoffs and remaining OpenAPI header-parameter limitation

## Tests
- cargo test --workspace

Closes #487