### PR TITLE
Add request header support to dynamic API calls

### DIFF
--- a/crates/onshape-client-io/src/lib.rs
+++ b/crates/onshape-client-io/src/lib.rs
@@ -489,6 +489,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_applies_request_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("should bind test server");
+        let address = listener
+            .local_addr()
+            .expect("should get test server address");
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("should accept request");
+            let mut buffer = [0_u8; 4096];
+            let received = stream.read(&mut buffer).expect("should read request");
+            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            assert!(
+                request.contains("x-onshape-test: header-value"),
+                "request should include custom request header, got: {request}"
+            );
+
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("should write response");
+        });
+
+        let client = OnshapeClient::new(ClientConfig {
+            base_url: format!("http://{address}"),
+            auth: ClientAuthConfig::Basic {
+                credentials: test_credentials(),
+            },
+            timeout: Some(Duration::from_secs(10)),
+        })
+        .expect("should create client");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "X-Onshape-Test",
+            http::HeaderValue::from_static("header-value"),
+        );
+        let request = ApiRequest {
+            method: http::Method::GET,
+            path: "/headers".to_string(),
+            query_params: Vec::new(),
+            headers,
+            body: None,
+            content_type: None,
+        };
+
+        let response = client
+            .execute(&request)
+            .await
+            .expect("request should succeed");
+        server.join().expect("server thread should finish");
+
+        assert_eq!(response.status, http::StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
     async fn execute_ignores_caller_authorization_header() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("should bind test server");
         let address = listener

--- a/crates/onshape-client-io/src/lib.rs
+++ b/crates/onshape-client-io/src/lib.rs
@@ -321,6 +321,28 @@ mod tests {
         }
     }
 
+    fn read_request_headers(stream: &mut std::net::TcpStream) -> String {
+        const MAX_HEADER_BYTES: usize = 16 * 1024;
+
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("should read request");
+            if read == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..read]);
+            assert!(
+                buffer.len() <= MAX_HEADER_BYTES,
+                "request headers should fit within {MAX_HEADER_BYTES} bytes"
+            );
+            if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        String::from_utf8_lossy(&buffer).to_lowercase()
+    }
+
     #[test]
     fn client_creation_succeeds_basic() {
         let client = OnshapeClient::new(test_config());
@@ -380,9 +402,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("should accept request");
-            let mut buffer = [0_u8; 4096];
-            let received = stream.read(&mut buffer).expect("should read request");
-            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            let request = read_request_headers(&mut stream);
             assert!(
                 request.contains("accept: application/json"),
                 "request should preserve JSON Accept header, got: {request}"
@@ -438,9 +458,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("should accept request");
-            let mut buffer = [0_u8; 4096];
-            let received = stream.read(&mut buffer).expect("should read request");
-            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            let request = read_request_headers(&mut stream);
             assert!(
                 request.contains("accept: application/octet-stream"),
                 "request should preserve explicit Accept header, got: {request}"
@@ -497,9 +515,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("should accept request");
-            let mut buffer = [0_u8; 4096];
-            let received = stream.read(&mut buffer).expect("should read request");
-            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            let request = read_request_headers(&mut stream);
             assert!(
                 request.contains("x-onshape-test: header-value"),
                 "request should include custom request header, got: {request}"
@@ -552,9 +568,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("should accept request");
-            let mut buffer = [0_u8; 4096];
-            let received = stream.read(&mut buffer).expect("should read request");
-            let request = String::from_utf8_lossy(&buffer[..received]).to_lowercase();
+            let request = read_request_headers(&mut stream);
             assert!(
                 request.contains("authorization: basic"),
                 "request should include executor-owned auth, got: {request}"

--- a/crates/onshape-mcp-core/Cargo.toml
+++ b/crates/onshape-mcp-core/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 base64.workspace = true
 chrono.workspace = true
+http.workspace = true
 onshape-client-core.workspace = true
 onshape-openapi.workspace = true
 onshape-mcp-resources.workspace = true
@@ -26,7 +27,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-http.workspace = true
 toml.workspace = true
 
 [lints]

--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use base64::Engine;
+use http::{HeaderMap, HeaderName, HeaderValue};
 
 use rmcp::{
     ErrorData,
@@ -291,6 +292,18 @@ fn validate_file_path(path: &str) -> Result<PathBuf, String> {
         ));
     }
     Ok(path_buf)
+}
+
+fn header_params_to_header_map(params: &HashMap<String, String>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in params {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| format!("invalid header name {name:?}: {e}"))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|e| format!("invalid value for header {name:?}: {e}"))?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(headers)
 }
 
 /// Convert a raw HTTP response from the Onshape API into a [`CallToolResult`].
@@ -974,6 +987,9 @@ pub struct ApiCallInput {
     /// Query parameters (e.g., `{"q": "robot arm", "limit": "10"}`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub query_params: HashMap<String, String>,
+    /// Header parameters (e.g., `{"Accept": "application/octet-stream"}`).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub header_params: HashMap<String, String>,
     /// JSON string for the request body (for POST/PUT/PATCH endpoints).
     /// Use `onshape_api_explain` to see the expected schema for each endpoint.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1370,16 +1386,18 @@ fn call_auth_status(
     };
 
     let empty_map = HashMap::new();
-    let request = match spec.build_request("sessionInfo", &empty_map, &empty_map, None) {
-        Ok(req) => req,
-        Err(e) => {
-            return ToolEffect::Done(Err(ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                format!("failed to build sessionInfo request: {e}"),
-                None,
-            )));
-        }
-    };
+    let empty_headers = HeaderMap::new();
+    let request =
+        match spec.build_request("sessionInfo", &empty_map, &empty_map, &empty_headers, None) {
+            Ok(req) => req,
+            Err(e) => {
+                return ToolEffect::Done(Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("failed to build sessionInfo request: {e}"),
+                    None,
+                )));
+            }
+        };
 
     ToolEffect::ApiRequest {
         request,
@@ -1509,10 +1527,16 @@ fn call_api_call(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -> 
         }
     }
 
+    let header_params = match header_params_to_header_map(&input.header_params) {
+        Ok(headers) => headers,
+        Err(msg) => return tool_input_error(msg),
+    };
+
     let request = match spec.build_request(
         &input.endpoint,
         &input.path_params,
         &input.query_params,
+        &header_params,
         body,
     ) {
         Ok(req) => req,
@@ -1924,6 +1948,7 @@ fn call_screenshot(arguments: Option<&Map<String, Value>>, spec: &OpenApiSpec) -
         "getPartStudioShadedViews",
         &path_params,
         &query_params,
+        &HeaderMap::new(),
         None,
     ) {
         Ok(req) => req,
@@ -4310,6 +4335,20 @@ mod tests {
         let input: ApiCallInput =
             serde_json::from_str(r#"{"endpoint": "getDocuments"}"#).expect("should parse");
         assert!(input.file_refs.is_empty());
+        assert!(input.header_params.is_empty());
+    }
+
+    #[test]
+    fn api_call_input_with_header_params_parses() {
+        let input: ApiCallInput = serde_json::from_str(
+            r#"{
+                "endpoint": "getDocuments",
+                "header_params": {"Accept": "application/octet-stream"}
+            }"#,
+        )
+        .expect("should parse");
+
+        assert_eq!(input.header_params["Accept"], "application/octet-stream");
     }
 
     #[test]
@@ -4366,6 +4405,60 @@ mod tests {
         // Should be a direct ApiRequest, no ReadFiles indirection.
         let (_request, continuation) = assert_api_request(effect);
         assert!(matches!(continuation, Continuation::FormatApiResponse));
+    }
+
+    #[test]
+    fn api_call_header_params_reach_request() {
+        let spec = test_spec();
+        let auth = not_configured();
+        let mut args = Map::new();
+        args.insert(
+            "endpoint".to_string(),
+            Value::String("getDocuments".to_string()),
+        );
+        args.insert(
+            "header_params".to_string(),
+            serde_json::json!({"Accept": "application/octet-stream"}),
+        );
+
+        let effect = call_tool(
+            "onshape_api_call",
+            Some(&args),
+            &auth,
+            &default_validation(),
+            Some(&spec),
+        );
+
+        let (request, continuation) = assert_api_request(effect);
+        assert!(matches!(continuation, Continuation::FormatApiResponse));
+        assert_eq!(request.headers["Accept"], "application/octet-stream");
+    }
+
+    #[test]
+    fn api_call_invalid_header_name_returns_error() {
+        let spec = test_spec();
+        let auth = not_configured();
+        let mut args = Map::new();
+        args.insert(
+            "endpoint".to_string(),
+            Value::String("getDocuments".to_string()),
+        );
+        args.insert(
+            "header_params".to_string(),
+            serde_json::json!({"not a header": "value"}),
+        );
+
+        let msg = assert_tool_error(call_tool(
+            "onshape_api_call",
+            Some(&args),
+            &auth,
+            &default_validation(),
+            Some(&spec),
+        ));
+        assert!(
+            msg.contains("invalid header name"),
+            "expected invalid header error, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -427,7 +427,8 @@ impl OpenApiSpec {
     /// Build an API request effect for a given endpoint.
     ///
     /// Validates that required path parameters are provided and substitutes them
-    /// into the path template. Query parameters and body are passed through.
+    /// into the path template. Query parameters, headers, and body are passed
+    /// through.
     ///
     /// # Errors
     ///
@@ -437,6 +438,7 @@ impl OpenApiSpec {
         endpoint_id: &str,
         path_params: &HashMap<String, String>,
         query_params: &HashMap<String, String>,
+        header_params: &HeaderMap,
         body: Option<Value>,
     ) -> Result<ApiRequest, OpenApiError> {
         let ep = self
@@ -480,12 +482,12 @@ impl OpenApiSpec {
         }
 
         for param in &ep.parameters {
-            if param.location == ParameterLocation::Header && param.required {
+            if param.location == ParameterLocation::Header
+                && param.required
+                && !header_params.contains_key(param.name.as_str())
+            {
                 return Err(OpenApiError::InvalidParams {
-                    reason: format!(
-                        "required header parameter `{}` is unsupported because dynamic request building does not accept header parameter values yet",
-                        param.name
-                    ),
+                    reason: format!("missing required header parameter: {}", param.name),
                 });
             }
         }
@@ -518,7 +520,7 @@ impl OpenApiSpec {
             method: ep.method.clone(),
             path: resolved_path,
             query_params: query_params_vec,
-            headers: HeaderMap::new(),
+            headers: header_params.clone(),
             body: request_body,
             content_type: ep.request_body_content_type.clone(),
         })
@@ -1610,7 +1612,13 @@ mod tests {
         path_params.insert("did".to_string(), "abc/123 model".to_string());
 
         let request = spec
-            .build_request("getDocument", &path_params, &HashMap::new(), None)
+            .build_request(
+                "getDocument",
+                &path_params,
+                &HashMap::new(),
+                &HeaderMap::new(),
+                None,
+            )
             .expect("should build");
 
         assert_eq!(request.method, Method::GET);
@@ -1623,7 +1631,13 @@ mod tests {
     fn build_request_missing_required_path_param() {
         let spec = OpenApiSpec::from_json(test_spec_json()).expect("should parse");
         let err = spec
-            .build_request("getDocument", &HashMap::new(), &HashMap::new(), None)
+            .build_request(
+                "getDocument",
+                &HashMap::new(),
+                &HashMap::new(),
+                &HeaderMap::new(),
+                None,
+            )
             .unwrap_err();
         assert!(matches!(err, OpenApiError::InvalidParams { .. }));
     }
@@ -1636,7 +1650,13 @@ mod tests {
         query_params.insert("limit".to_string(), "10".to_string());
 
         let request = spec
-            .build_request("getDocuments", &HashMap::new(), &query_params, None)
+            .build_request(
+                "getDocuments",
+                &HashMap::new(),
+                &query_params,
+                &HeaderMap::new(),
+                None,
+            )
             .expect("should build");
 
         assert_eq!(request.method, Method::GET);
@@ -1677,7 +1697,13 @@ mod tests {
         .expect("should parse");
 
         let err = spec
-            .build_request("searchDocuments", &HashMap::new(), &HashMap::new(), None)
+            .build_request(
+                "searchDocuments",
+                &HashMap::new(),
+                &HashMap::new(),
+                &HeaderMap::new(),
+                None,
+            )
             .unwrap_err();
 
         match err {
@@ -1692,7 +1718,55 @@ mod tests {
     }
 
     #[test]
-    fn build_request_rejects_required_header_params() {
+    fn build_request_with_required_header_params() {
+        let spec = OpenApiSpec::from_value(&serde_json::json!({
+            "openapi": "3.0.1",
+            "servers": [{ "url": "https://example.com/api/v1" }],
+            "paths": {
+                "/downloads/{did}": {
+                    "get": {
+                        "operationId": "downloadExternalData",
+                        "parameters": [
+                            {
+                                "name": "did",
+                                "in": "path",
+                                "required": true,
+                                "schema": { "type": "string" }
+                            },
+                            {
+                                "name": "If-Match",
+                                "in": "header",
+                                "required": true,
+                                "schema": { "type": "string" }
+                            }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        }))
+        .expect("should parse");
+        let mut path_params = HashMap::new();
+        path_params.insert("did".to_string(), "doc1".to_string());
+        let mut header_params = HeaderMap::new();
+        header_params.insert("If-Match", "revision-1".parse().expect("valid header"));
+
+        let request = spec
+            .build_request(
+                "downloadExternalData",
+                &path_params,
+                &HashMap::new(),
+                &header_params,
+                None,
+            )
+            .expect("should build");
+
+        assert_eq!(request.path, "/downloads/doc1");
+        assert_eq!(request.headers["If-Match"], "revision-1");
+    }
+
+    #[test]
+    fn build_request_rejects_missing_required_header_params() {
         let spec = OpenApiSpec::from_value(&serde_json::json!({
             "openapi": "3.0.1",
             "servers": [{ "url": "https://example.com/api/v1" }],
@@ -1724,18 +1798,20 @@ mod tests {
         path_params.insert("did".to_string(), "doc1".to_string());
 
         let err = spec
-            .build_request("downloadExternalData", &path_params, &HashMap::new(), None)
+            .build_request(
+                "downloadExternalData",
+                &path_params,
+                &HashMap::new(),
+                &HeaderMap::new(),
+                None,
+            )
             .unwrap_err();
 
         match err {
             OpenApiError::InvalidParams { reason } => {
                 assert!(
-                    reason.contains("required header parameter `If-Match` is unsupported"),
-                    "error should mention unsupported required header, got: {reason}"
-                );
-                assert!(
-                    reason.contains("does not accept header parameter values yet"),
-                    "error should explain dynamic request input limitation, got: {reason}"
+                    reason.contains("missing required header parameter: If-Match"),
+                    "error should mention missing required header, got: {reason}"
                 );
             }
             other => panic!("expected InvalidParams, got {other:?}"),
@@ -1752,6 +1828,7 @@ mod tests {
                 "createDocument",
                 &HashMap::new(),
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .expect("should build");
@@ -2042,6 +2119,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .expect("should build");
@@ -2088,6 +2166,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .unwrap_err();
@@ -2120,6 +2199,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .unwrap_err();
@@ -2149,6 +2229,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .unwrap_err();
@@ -2182,6 +2263,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body),
             )
             .expect("should build");
@@ -2211,6 +2293,7 @@ mod tests {
                 "uploadFileCreateElement",
                 &path_params,
                 &HashMap::new(),
+                &HeaderMap::new(),
                 None,
             )
             .expect("should build");
@@ -2228,6 +2311,7 @@ mod tests {
                 "createDocument",
                 &HashMap::new(),
                 &HashMap::new(),
+                &HeaderMap::new(),
                 Some(body.clone()),
             )
             .expect("should build");

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -283,6 +283,7 @@ impl OpenApiSpec {
             let Some(methods) = methods_val.as_object() else {
                 continue;
             };
+            let path_parameters = Self::parse_parameters(methods_val);
             for (method_str, detail) in methods {
                 let Ok(method) = Method::from_bytes(method_str.to_ascii_uppercase().as_bytes())
                 else {
@@ -292,8 +293,14 @@ impl OpenApiSpec {
                     continue;
                 };
 
-                let endpoint =
-                    Self::parse_endpoint(operation_id, method, path, detail, &components);
+                let endpoint = Self::parse_endpoint(
+                    operation_id,
+                    method,
+                    path,
+                    detail,
+                    &path_parameters,
+                    &components,
+                );
                 if endpoints
                     .insert(operation_id.to_string(), endpoint)
                     .is_none()
@@ -867,6 +874,7 @@ impl OpenApiSpec {
         method: Method,
         path: &str,
         detail: &Value,
+        path_parameters: &[ParsedParameter],
         components: &HashMap<String, Value>,
     ) -> ParsedEndpoint {
         let summary = detail
@@ -892,7 +900,7 @@ impl OpenApiSpec {
             })
             .unwrap_or_default();
 
-        let parameters = Self::parse_parameters(detail);
+        let parameters = Self::merge_parameters(path_parameters, Self::parse_parameters(detail));
         let (has_request_body, request_body_schema, request_body_content_type) =
             Self::parse_request_body(detail, components);
         let response_schema = Self::parse_response_schema(detail, components);
@@ -970,6 +978,26 @@ impl OpenApiSpec {
                 })
             })
             .collect()
+    }
+
+    fn merge_parameters(
+        path_parameters: &[ParsedParameter],
+        operation_parameters: Vec<ParsedParameter>,
+    ) -> Vec<ParsedParameter> {
+        let mut parameters = path_parameters.to_vec();
+
+        for operation_parameter in operation_parameters {
+            if let Some(existing) = parameters.iter_mut().find(|parameter| {
+                parameter.name == operation_parameter.name
+                    && parameter.location == operation_parameter.location
+            }) {
+                *existing = operation_parameter;
+            } else {
+                parameters.push(operation_parameter);
+            }
+        }
+
+        parameters
     }
 
     fn parse_request_body(
@@ -1816,6 +1844,106 @@ mod tests {
             }
             other => panic!("expected InvalidParams, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn path_item_parameters_are_merged_with_operation_parameters() {
+        let spec = OpenApiSpec::from_value(&serde_json::json!({
+            "openapi": "3.0.1",
+            "servers": [{ "url": "https://example.com/api/v1" }],
+            "paths": {
+                "/downloads/{did}": {
+                    "parameters": [
+                        {
+                            "name": "did",
+                            "in": "path",
+                            "required": true,
+                            "schema": { "type": "string" }
+                        },
+                        {
+                            "name": "If-Match",
+                            "in": "header",
+                            "required": true,
+                            "description": "path-level required header",
+                            "schema": { "type": "string" }
+                        },
+                        {
+                            "name": "X-Override",
+                            "in": "header",
+                            "required": true,
+                            "description": "path-level header",
+                            "schema": { "type": "string" }
+                        }
+                    ],
+                    "get": {
+                        "operationId": "downloadExternalData",
+                        "parameters": [
+                            {
+                                "name": "X-Override",
+                                "in": "header",
+                                "required": false,
+                                "description": "operation-level header",
+                                "schema": { "type": "string" }
+                            }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                    }
+                }
+            }
+        }))
+        .expect("should parse");
+
+        let detail = spec
+            .explain("downloadExternalData")
+            .expect("should explain endpoint");
+        let if_match = detail
+            .parameters
+            .iter()
+            .find(|parameter| parameter.name == "If-Match")
+            .expect("should inherit path-item header parameter");
+        assert_eq!(if_match.location, ParameterLocation::Header);
+        assert!(if_match.required);
+
+        let override_header = detail
+            .parameters
+            .iter()
+            .find(|parameter| parameter.name == "X-Override")
+            .expect("should keep overridden header parameter");
+        assert_eq!(override_header.location, ParameterLocation::Header);
+        assert!(!override_header.required);
+        assert_eq!(override_header.description, "operation-level header");
+
+        let mut path_params = HashMap::new();
+        path_params.insert("did".to_string(), "doc1".to_string());
+        let missing_header_err = spec
+            .build_request(
+                "downloadExternalData",
+                &path_params,
+                &HashMap::new(),
+                &HeaderMap::new(),
+                None,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(&missing_header_err, OpenApiError::InvalidParams { reason } if reason.contains("missing required header parameter: If-Match")),
+            "expected missing inherited required header error, got: {missing_header_err:?}"
+        );
+
+        let mut header_params = HeaderMap::new();
+        header_params.insert("If-Match", "revision-1".parse().expect("valid header"));
+        let request = spec
+            .build_request(
+                "downloadExternalData",
+                &path_params,
+                &HashMap::new(),
+                &header_params,
+                None,
+            )
+            .expect("should build with inherited required header");
+
+        assert_eq!(request.path, "/downloads/doc1");
+        assert_eq!(request.headers["If-Match"], "revision-1");
+        assert!(!request.headers.contains_key("X-Override"));
     }
 
     #[test]

--- a/docs/src/project/common-onshape-client-plan.md
+++ b/docs/src/project/common-onshape-client-plan.md
@@ -48,9 +48,9 @@ what decision or dependency is missing.
   type.
 - Request headers are modeled with `http::HeaderMap`; preserve the existing
   JSON-oriented default `Accept` behavior until a request explicitly overrides it.
-- Until dynamic OpenAPI request building accepts header parameter inputs, it must
-  not silently drop header parameters. Required header parameters should make
-  request construction fail with a clear unsupported-parameter error.
+- Dynamic OpenAPI request building accepts header parameter inputs as
+  `http::HeaderMap`, preserving the standard HTTP boundary type. Required header
+  parameters make request construction fail only when missing.
 - Represent response headers as `http::HeaderMap` so common callers can inspect
   standard HTTP metadata without coupling to a network framework.
 - Convert buffered response bytes to text only at the MCP boundary. Existing MCP
@@ -255,9 +255,9 @@ responses; callers decide how to interpret them.
   an explicit `Accept` header.
 - Model request headers as `http::HeaderMap` while keeping authentication
   executor-owned.
-- Dynamic OpenAPI request building should reject endpoints with required header
-  parameters for now, because its public input shape cannot accept separate
-  header parameter values yet. Do not silently omit required headers.
+- Dynamic OpenAPI request building accepts request headers as `http::HeaderMap`.
+  MCP-facing JSON input converts `header_params` into that type before request
+  construction. Do not silently omit required headers.
 
 ### 3. Adapt MCP at the Boundary
 
@@ -340,8 +340,8 @@ in shared decisions such as proactive refresh margins and retry-on-401 behavior.
 Ensure coverage exists for:
 
 - path and query parameter substitution.
-- required header parameters are rejected until dynamic OpenAPI request building
-  has a header-parameter input map.
+- required header parameters are accepted when supplied through dynamic OpenAPI
+  request building's header-parameter input map.
 - JSON body request building.
 - multipart binary and text body building.
 - schema lookup with `allOf`.
@@ -388,7 +388,8 @@ Implemented focused first helper set:
 - Request builders cite the `OpenAPI` operation IDs they implement and have
   golden tests for method, path, body, and content type construction.
 - Endpoint-specific download media negotiation remains a separate `Accept`
-  follow-up; the common request model can now carry request headers.
+  follow-up; the common request model and dynamic OpenAPI builder can now carry
+  request headers.
 
 Place these initially under `onshape-client-core::endpoints::*`, separate from
 low-level `request`, `response`, `auth`, and `oauth` modules. Helpers must build
@@ -453,8 +454,8 @@ Focused test coverage for this extraction step:
 
 - byte response helpers, including strict UTF-8 failure behavior.
 - MCP edge conversion from byte responses into existing text/JSON continuations.
-- OpenAPI request building rejects required header parameters while request
-  headers are unsupported.
+- OpenAPI request building accepts required header parameters and rejects them
+  only when missing.
 - direct and proxy OAuth token-file fixtures preserve the current flat MCP JSON
   shape through the token-material split.
 - shared pure refresh decision helpers cover proactive refresh and retry-on-401

--- a/docs/src/project/http-types-plan.md
+++ b/docs/src/project/http-types-plan.md
@@ -62,9 +62,9 @@ common client boundary:
   setting authentication. Caller-supplied `Authorization` is overwritten by
   executor-owned auth, and `Accept: application/json` remains the default when no
   explicit `Accept` is present.
-- Dynamic OpenAPI request construction still rejects required header parameters
-  because its public input shape has no separate header-parameter map yet; that
-  remains part of the request-header/`Accept` follow-up.
+- Dynamic OpenAPI request construction accepts request headers as
+  `http::HeaderMap`; MCP-facing JSON input converts `header_params` into that
+  standard HTTP type before building an `ApiRequest`.
 
 Do not revisit this decision without a concrete problem from real common-client
 or export-service usage.

--- a/docs/src/project/mcp-tools.md
+++ b/docs/src/project/mcp-tools.md
@@ -275,9 +275,15 @@ Invoke an Onshape API endpoint with structured parameters. Path parameters are n
 | `endpoint` | `string` | Yes | The operation ID to call |
 | `path_params` | `object` | No | Path parameters (e.g., `{"did": "abc123"}`) |
 | `query_params` | `object` | No | Query parameters (e.g., `{"q": "robot arm", "limit": "10"}`) |
+| `header_params` | `object` | No | Header parameters (e.g., `{"Accept": "application/octet-stream"}`) |
 | `body` | `any` | No | Request body (for POST/PUT/PATCH endpoints) |
+| `file_refs` | `array` | No | File content to inject into multipart or JSON request body fields |
 
 **Output:** The API response content.
+
+`header_params` can set request headers such as `Accept`. Authentication remains
+executor-owned; caller-supplied `Authorization` headers are ignored and replaced
+with the configured Onshape credentials.
 
 **Effect Pattern:** This tool uses the effects-as-data pattern. The core crate validates the request and produces an `ApiRequest` effect, which the I/O layer executes. This keeps the core crate sans-IO.
 


### PR DESCRIPTION
## Summary
- add HeaderMap input support to OpenAPI dynamic request building
- expose JSON-friendly header_params on onshape_api_call and convert them to HeaderMap
- update tests/docs for explicit headers, required OpenAPI header params, and executor-owned auth

## Tests
- cargo test -p onshape-client-core -p onshape-client-io -p onshape-openapi -p onshape-mcp-core
- cargo test --workspace
- cargo clippy --workspace --all-targets

Closes #485