### PR TITLE
Work around Codecov key import failure

### DIFF
--- a/.github/workflows/reflow-coverage.yml
+++ b/.github/workflows/reflow-coverage.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
+          # Workaround for Codecov action Keybase GPG key import failure:
+          # https://github.com/codecov/codecov-action/issues/1955#issuecomment-4640001038
+          use_pypi: true
           use_oidc: true
           files: lcov.info
           flags: rust

--- a/.github/workflows/reflow-npm.yml
+++ b/.github/workflows/reflow-npm.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
+          # Workaround for Codecov action Keybase GPG key import failure:
+          # https://github.com/codecov/codecov-action/issues/1955#issuecomment-4640001038
+          use_pypi: true
           use_oidc: true
           files: npm/onshape-mcp/coverage/lcov.info
           flags: npm


### PR DESCRIPTION
## Summary
- add Codecov `use_pypi` workaround to Rust coverage upload
- add the same workaround to npm coverage upload
- link each workflow comment to the Codecov issue comment documenting the workaround

## Tests
- `actionlint .github/workflows/reflow-coverage.yml .github/workflows/reflow-npm.yml`
- pre-commit hooks during commit