### PR TITLE
Verify 3MF export parameters

### DIFF
--- a/crates/onshape-client-core/src/endpoints.rs
+++ b/crates/onshape-client-core/src/endpoints.rs
@@ -22,7 +22,10 @@ pub use external_data::download_external_data;
 pub use shared::{
     ElementRef, Error, WorkspaceVersion, WorkspaceVersionMicroversion, WvmElementRef,
 };
-pub use translations::{TranslationRequestInfo, TranslationRequestState};
+pub use translations::{
+    MeshTranslationRequestBody, TranslationMeshParams, TranslationRequestInfo,
+    TranslationRequestState,
+};
 pub use translations::{
     create_assembly_translation, create_part_studio_translation, get_all_translator_formats,
     get_translation, parse_translation_request_info,

--- a/crates/onshape-client-core/src/endpoints/translations.rs
+++ b/crates/onshape-client-core/src/endpoints/translations.rs
@@ -4,6 +4,54 @@ use crate::endpoints::shared::{ElementRef, Error, element_path, encode_path_segm
 use crate::request::{ApiRequest, ApiResponse};
 use http::{HeaderMap, Method};
 
+/// Mesh tessellation options for generic translation request bodies.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationMeshParams<'a> {
+    /// Maximum angular deviation between analytical surfaces and triangulation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub angular_tolerance: Option<f64>,
+    /// Maximum distance deviation between analytical surfaces and triangulation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distance_tolerance: Option<f64>,
+    /// Maximum triangle edge length.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum_chord_length: Option<f64>,
+    /// Export resolution, such as `fine`, `medium`, or `coarse`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<&'a str>,
+    /// Export unit, using Onshape's `GBTExportUnit` wire value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<&'a str>,
+}
+
+/// Typed request body for generic mesh translation endpoints, including 3MF.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshTranslationRequestBody<'a> {
+    /// The name of the exported file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination_name: Option<&'a str>,
+    /// Whether to exclude hidden parts from export.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclude_hidden_entities: Option<bool>,
+    /// The name of the file format, such as `3MF`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format_name: Option<&'a str>,
+    /// Mesh tessellation options. These serialize as flat translation fields.
+    #[serde(flatten)]
+    pub mesh_params: TranslationMeshParams<'a>,
+    /// Send notification to the user client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notify_user: Option<bool>,
+    /// Create a blob with exported file in the source document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store_in_document: Option<bool>,
+    /// Automatically download a translated file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_auto_download: Option<bool>,
+}
+
 /// Minimal parsed response for `BTTranslationRequestInfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -225,6 +273,86 @@ mod tests {
             "/partstudios/d/doc%2F1/v/ver%201/e/elem%2B1/translations",
             "STL",
         );
+    }
+
+    #[test]
+    fn mesh_translation_request_body_serializes_golden_json() {
+        let body = MeshTranslationRequestBody {
+            destination_name: Some("coarse-model"),
+            exclude_hidden_entities: Some(true),
+            format_name: Some("3MF"),
+            mesh_params: TranslationMeshParams {
+                angular_tolerance: Some(0.5),
+                distance_tolerance: Some(0.01),
+                maximum_chord_length: Some(0.1),
+                resolution: Some("coarse"),
+                unit: Some("MILLIMETER"),
+            },
+            notify_user: Some(false),
+            store_in_document: Some(false),
+            trigger_auto_download: Some(false),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&body).expect("body should serialize"),
+            json!({
+                "angularTolerance": 0.5,
+                "destinationName": "coarse-model",
+                "distanceTolerance": 0.01,
+                "excludeHiddenEntities": true,
+                "formatName": "3MF",
+                "maximumChordLength": 0.1,
+                "notifyUser": false,
+                "resolution": "coarse",
+                "storeInDocument": false,
+                "triggerAutoDownload": false,
+                "unit": "MILLIMETER"
+            })
+        );
+    }
+
+    #[test]
+    fn typed_mesh_translation_body_omits_unset_fields() {
+        assert_eq!(
+            serde_json::to_value(MeshTranslationRequestBody::default())
+                .expect("body should serialize"),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn create_part_studio_translation_accepts_typed_mesh_body() {
+        let body = MeshTranslationRequestBody {
+            destination_name: Some("export-name"),
+            format_name: Some("3MF"),
+            mesh_params: TranslationMeshParams {
+                angular_tolerance: Some(0.5),
+                distance_tolerance: Some(0.01),
+                maximum_chord_length: Some(0.1),
+                resolution: Some("coarse"),
+                unit: Some("MILLIMETER"),
+            },
+            notify_user: Some(false),
+            store_in_document: Some(false),
+            ..MeshTranslationRequestBody::default()
+        };
+
+        let request =
+            create_part_studio_translation(target(), &body).expect("request should build");
+
+        assert_json_post(
+            &request,
+            "/partstudios/d/doc%2F1/v/ver%201/e/elem%2B1/translations",
+            "3MF",
+        );
+        let body = request
+            .body
+            .as_ref()
+            .and_then(RequestBody::as_json)
+            .expect("request should have a JSON body");
+        assert_eq!(body["angularTolerance"], 0.5);
+        assert_eq!(body["resolution"], "coarse");
+        assert_eq!(body["unit"], "MILLIMETER");
     }
 
     #[test]

--- a/docs/src/project/external-data-downloads.md
+++ b/docs/src/project/external-data-downloads.md
@@ -17,13 +17,14 @@ translation context.
 
 ## Verified Behavior
 
-Verification was run on 2026-06-06 against Onshape API v14 using the public
-CRANK Part Studio from Onshape's translation guide:
+Verification was run on 2026-06-06 and 2026-06-07 against Onshape API v14 using
+the public CRANK document from Onshape's translation guide:
 
 ```text
 did:  e60c4803eaf2ac8be492c18e
 wid:  d2558da712764516cc9fec62
-eid:  6bed6b43463f6a46a37b4a22
+Part Studio eid:  6bed6b43463f6a46a37b4a22
+Assembly eid:     23a9385cd48c50167c32d6d1
 ```
 
 The exports used `storeInDocument=false`, so completed translations returned
@@ -34,12 +35,42 @@ external data IDs instead of blob element IDs.
 | STEP | `createPartStudioTranslation` with `formatName=STEP` | `200`, direct response | `application/octet-stream;charset=utf-8` | 2053444 |
 | STL | `createPartStudioTranslation` with `formatName=STL` | `200`, direct response | `application/octet-stream;charset=utf-8` | 3861140 |
 | glTF | `createPartStudioExportGltf` with `storeInDocument=false` | `200`, direct response | `application/zip;charset=utf-8` | 18881470 |
+| 3MF | `createPartStudioTranslation` with coarse mesh detail parameters | `200`, direct response | binary wrapper did not expose headers | body starts with ZIP `PK` signature |
+| 3MF | `translateFormat` for Assembly with coarse mesh detail parameters | `200`, direct response | binary wrapper did not expose headers | body starts with ZIP `PK` signature |
 
-3MF was attempted through `createPartStudioTranslation` with `formatName=3MF`.
-One request without detail parameters failed with `Invalid 3MF detail parameters
-were specified`; a retry with explicit tessellation parameters also failed. This
-did not produce an external-data artifact to download, so 3MF-specific export
-parameters need separate investigation before comparing its artifact headers.
+`getAllTranslatorFormats` reports `3MF` as `validDestinationFormat=true`,
+`couldBeAssembly=true`, and `contentType=application/3mf`. Minimal 3MF requests
+failed quickly through `createPartStudioTranslation` with `Invalid 3MF detail
+parameters were specified`, including a variant that only added `translate=true`.
+Fine-detail mesh requests were accepted but later failed: the Part Studio result
+reported a generic `failed to translate`, and the Assembly result reported
+`Memory limit exceeded. Reducing file size may allow translation to succeed`.
+
+The working 3MF requests used coarse flat tessellation fields on the generic
+translation endpoints:
+
+```json
+{
+  "formatName": "3MF",
+  "storeInDocument": false,
+  "destinationName": "crank-3mf-coarse",
+  "notifyUser": false,
+  "angularTolerance": 0.5,
+  "distanceTolerance": 0.01,
+  "maximumChordLength": 0.1,
+  "resolution": "coarse",
+  "unit": "MILLIMETER"
+}
+```
+
+The Part Studio translation completed with `resultExternalDataIds` containing
+`6a2575236577e5fca6796d82`. The Assembly translation completed with
+`resultExternalDataIds` containing `6a2575246577e5fca6796d84`. Downloading each
+external-data ID returned a binary artifact with a ZIP signature and an internal
+`3D/3dmodel.model` entry, consistent with a 3MF package. The MCP API wrapper used
+for the live check returned the binary body but did not expose response headers,
+so exact 3MF `Content-Type`, `Content-Disposition`, `ETag`, and filename behavior
+still need raw HTTP header capture before being compared to STEP, STL, and glTF.
 
 ## Accept Header
 
@@ -86,6 +117,11 @@ Completed artifact responses included these useful headers:
 `If-None-Match` with the returned STEP `ETag` produced `304` with
 `Content-Length: 0` and no response body.
 
+The successful 3MF artifacts were downloaded and verified as binary 3MF package
+bodies, but exact response headers were not captured during the 2026-06-07 live
+check because the available API wrapper did not return headers for binary
+responses.
+
 ## Client Guidance
 
 - Build the download request from the source document ID and
@@ -96,6 +132,10 @@ Completed artifact responses included these useful headers:
 - Treat `Content-Length` as optional; rely on the actual bytes read when
   buffering or streaming.
 - Preserve `ETag` when caching artifacts and use `If-None-Match` for validation.
+- For 3MF, provide flat mesh detail fields on the generic translation request;
+  minimal `formatName=3MF` requests can fail validation.
+- Use coarse tessellation or otherwise control triangle count for 3MF when
+  exporting larger Part Studios or Assemblies.
 - No absolute-URL or redirect-specific helper is needed for the verified
   external-data path. Revisit this only if another external-data host or redirect
   appears in future verification.


### PR DESCRIPTION
## Summary
- document the verified coarse 3MF export flow for Part Studios and Assemblies
- add typed flat mesh translation request bodies for generic translation endpoints
- add golden serialization and request tests for 3MF-style mesh translation bodies

## Verification
- cargo fmt --all --check
- cargo test -p onshape-client-core endpoints
- cargo test -p onshape-client-core
- cargo clippy -p onshape-client-core --all-targets --all-features -- -D warnings

Closes #508