### PR TITLE
ci: use Renovate client ID variable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
-          client-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14


### PR DESCRIPTION
## Summary
- update Renovate GitHub App token creation to read vars.RENOVATE_CLIENT_ID
- leave RENOVATE_APP_PRIVATE_KEY unchanged

## Testing
- pre-commit hooks during commit, including GitHub Actions workflow validation