### PR TITLE
Add mdBook docs check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,13 @@ repos:
         files: (^mise\.toml$|^mise\.lock$)
         pass_filenames: false
 
+      - id: mdbook-build
+        name: mdbook build
+        entry: mise exec -- mdbook build docs
+        language: system
+        files: ^docs/
+        pass_filenames: false
+
       - id: sync-versions
         name: sync versions
         entry: node scripts/sync-versions.js

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,7 @@
+[book]
+title = "Onshape MCP"
+src = "src"
+
+[build]
+build-dir = "book"
+create-missing = false

--- a/mise.lock
+++ b/mise.lock
@@ -132,6 +132,10 @@ url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.17.6/ca
 version = "0.24.0"
 backend = "cargo:lychee"
 
+[[tools."cargo:mdbook"]]
+version = "0.5.3"
+backend = "cargo:mdbook"
+
 [[tools."github:nextest-rs/nextest"]]
 version = "0.9.137"
 backend = "github:nextest-rs/nextest"

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@ cargo-binstall = "latest"
 # (macOS Intel). The lychee project dropped macOS Intel binaries after v0.15.1
 # (April 2024), so the aqua backend cannot cover all CI platforms.
 "cargo:lychee" = "0.24.0"
+"cargo:mdbook" = "0.5.3"
 "npm:wrangler" = "4.98.0"
 "aqua:superfly/flyctl" = "0.4.58"
 


### PR DESCRIPTION
## Summary
- add mdBook configuration for docs/src
- pin mdBook in mise and lock it for the configured platforms
- run mdBook through pre-commit via mise exec

## Testing
- mise install --locked --dry-run
- mise exec -- mdbook build docs
- pre-commit run mdbook-build --all-files
- pre-commit run check-toml --all-files
- pre-commit run check-yaml --all-files
- commit hooks