### PR TITLE
Remove Codecov PyPI workaround

### DIFF
--- a/.github/workflows/reflow-coverage.yml
+++ b/.github/workflows/reflow-coverage.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          # Workaround for Codecov action Keybase GPG key import failure:
-          # https://github.com/codecov/codecov-action/issues/1955#issuecomment-4640001038
-          use_pypi: true
           use_oidc: true
           files: lcov.info
           flags: rust

--- a/.github/workflows/reflow-npm.yml
+++ b/.github/workflows/reflow-npm.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          # Workaround for Codecov action Keybase GPG key import failure:
-          # https://github.com/codecov/codecov-action/issues/1955#issuecomment-4640001038
-          use_pypi: true
           use_oidc: true
           files: npm/onshape-mcp/coverage/lcov.info
           flags: npm


### PR DESCRIPTION
## Summary

- Remove the obsolete `use_pypi` Codecov action workaround from Rust and npm coverage uploads.
- Remove the associated Keybase workaround comments referencing Codecov issue #1955.
- Preserve OIDC, coverage files, flags, `fail_ci_if_error`, and the `jdx/mise-action` digest.

## Validation

- `pre-commit run check-yaml --files .github/workflows/reflow-coverage.yml .github/workflows/reflow-npm.yml`
- `pre-commit run actionlint --files .github/workflows/reflow-coverage.yml .github/workflows/reflow-npm.yml`
- `pre-commit run action-validator --files .github/workflows/reflow-coverage.yml .github/workflows/reflow-npm.yml`
- `git diff --check`
