### PR TITLE
Reapprove updated Renovate PRs with Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,6 +25,7 @@ pull_request_rules:
   - name: Automatically approve Renovate PRs
     conditions:
       - author = altendky-renovate[bot]
+      - github-review-decision = REVIEW_REQUIRED
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Summary

- require GitHub's effective review decision to be `REVIEW_REQUIRED` before Mergify auto-approves a Renovate PR
- allow the approval rule to match again after Renovate updates dismiss a stale approval

## Testing

- `pre-commit run --files .mergify.yml`
