### PR TITLE
Update lychee to 0.24.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: markdownlint-cli2
 
   - repo: https://github.com/lycheeverse/lychee
-    rev: lychee-v0.24.0
+    rev: lychee-v0.24.2
     hooks:
       - id: lychee-system
         args: ["--no-progress", "--config=.lychee.toml"]

--- a/mise.lock
+++ b/mise.lock
@@ -129,7 +129,7 @@ checksum = "sha256:5fcbddde2d415704d2432bbe606a5767ddaf1ef4ee2c16b7828f8be2ed1e5
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.17.6/cargo-binstall-x86_64-pc-windows-msvc.zip"
 
 [[tools."cargo:lychee"]]
-version = "0.24.0"
+version = "0.24.2"
 backend = "cargo:lychee"
 
 [[tools."cargo:mdbook"]]

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ cargo-binstall = "latest"
 # compilation is used as a fallback on platforms without pre-built binaries
 # (macOS Intel). The lychee project dropped macOS Intel binaries after v0.15.1
 # (April 2024), so the aqua backend cannot cover all CI platforms.
-"cargo:lychee" = "0.24.0"
+"cargo:lychee" = "0.24.2"
 "cargo:mdbook" = "0.5.3"
 "npm:wrangler" = "4.101.0"
 "aqua:superfly/flyctl" = "0.4.59"


### PR DESCRIPTION
## Summary

- upgrade lychee from 0.24.0 to 0.24.2 in mise and pre-commit configuration
- refresh the focused `mise.lock` entry without unrelated lockfile churn
- restore usable prebuilt release assets in 0.24.2, preventing the cold-cache cargo fallback failure

## Verification

- `mise run lock-tool cargo:lychee`
- `mise install --force --verbose cargo:lychee@0.24.2` (cargo-binstall downloaded the GitHub prebuilt binary with compilation disabled)
- `mise exec cargo:lychee@0.24.2 -- lychee --version`
- `mise install --locked --dry-run`
- `mise exec -- pre-commit validate-config .pre-commit-config.yaml`
- `mise exec -- pre-commit run check-toml --files mise.toml mise.lock`
- `mise exec -- pre-commit run check-yaml --files .pre-commit-config.yaml`
- `mise exec -- pre-commit run mise-lock --files mise.toml mise.lock`
- `mise exec -- pre-commit run lychee-system --all-files`
- `git diff --check`
