### PR TITLE
Fix OpenCode MCP environment configuration

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -14,7 +14,7 @@
     "onshape-npm-debug": {
       "type": "local",
       "command": ["node", "npm/onshape-mcp/bin.js"],
-      "environment": {
+      "env": {
         "ONSHAPE_MCP_NPM_COMMAND": "./target/debug/onshape-mcp"
       },
       "enabled": true
@@ -22,7 +22,7 @@
     "onshape-npm-release": {
       "type": "local",
       "command": ["node", "npm/onshape-mcp/bin.js"],
-      "environment": {
+      "env": {
         "ONSHAPE_MCP_NPM_COMMAND": "./target/release/onshape-mcp"
       },
       "enabled": false


### PR DESCRIPTION
## Summary

- use OpenCode's supported `env` field for npm MCP launch environment variables
- restore the debug and release binary overrides used by the local npm wrapper configurations

## Testing

- `opencode mcp list` reports `onshape-npm-debug` as connected
- pre-commit hooks passed
