### PR TITLE
Prepare v0.5.0 release readiness

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - "altendky-renovate[bot]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   checks:
     name: checks
     if: ${{ !cancelled() }}
-    needs: [mise, pre-commit, rust, coverage, npm, error-enums]
+    needs: [mise, pre-commit, rust, coverage, npm, version, error-enums]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1

--- a/.github/workflows/reflow-publish-release.yml
+++ b/.github/workflows/reflow-publish-release.yml
@@ -89,6 +89,12 @@ jobs:
             exit 1
           fi
 
+      - name: Prepare curated release notes
+        if: inputs.publish
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node scripts/release-changelog.js extract "$VERSION" > dist/release-notes.md
+
       - name: Create GitHub Release
         if: inputs.publish
         env:
@@ -108,4 +114,5 @@ jobs:
           gh release create "$TAG" \
             --title "v${VERSION}" \
             --generate-notes \
+            --notes-file dist/release-notes.md \
             "${assets[@]}"

--- a/.github/workflows/reflow-release-npm.yml
+++ b/.github/workflows/reflow-release-npm.yml
@@ -72,6 +72,18 @@ jobs:
           echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
           echo "Platform directories: $dirs"
 
+      - name: Verify npm publish inventory
+        shell: bash
+        env:
+          PLATFORM_DIRS: ${{ steps.platform-dirs.outputs.dirs }}
+        run: |
+          platform_packages=()
+          for package_dir in $PLATFORM_DIRS; do
+            platform_packages+=("$(basename "$package_dir")")
+          done
+          node scripts/sync-versions.js --check-npm-publish-inventory \
+            onshape-mcp opencode-auth "${platform_packages[@]}"
+
       - name: Update package.json files to target version
         shell: bash
         env:

--- a/.github/workflows/reflow-release-version.yml
+++ b/.github/workflows/reflow-release-version.yml
@@ -36,7 +36,23 @@ jobs:
           echo "Cargo.toml version: $version"
 
       - name: Check version sync
-        run: node scripts/sync-versions.js --check
+        run: |
+          node --test scripts/release-changelog.test.js
+          node --test scripts/sync-versions.test.js
+          node scripts/sync-versions.js --check
+
+      - name: Validate release changelog
+        env:
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if [[ "$REF_TYPE" == "tag" || "$REF_NAME" == "release/v${VERSION}" ]]; then
+            node scripts/release-changelog.js extract "$VERSION" > /dev/null
+          else
+            node scripts/release-changelog.js validate-if-present "$VERSION"
+          fi
 
       - name: Verify tag matches Cargo.toml version
         if: inputs.git-tag != ''

--- a/.github/workflows/reflow-tag-release.yml
+++ b/.github/workflows/reflow-tag-release.yml
@@ -53,7 +53,9 @@ jobs:
 
       - name: Create and push tag
         if: steps.check.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
         run: |
-          version="${{ steps.check.outputs.version }}"
-          git tag "v${version}"
-          git push origin "v${version}"
+          node scripts/release-changelog.js extract "$VERSION" > /dev/null
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"

--- a/docs/src/project/changelog.md
+++ b/docs/src/project/changelog.md
@@ -7,15 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Upgraded to rmcp 2.2 and the MCP 2025-11-25 model API; public Rust resource
-  and content types now use `Resource` and `ContentBlock`
-
 ### Added
 
-- Initial project documentation structure
-- Generic API tools (`onshape_api_search`, `onshape_api_explain`, `onshape_api_call`) powered by embedded Onshape OpenAPI specification
-- OpenAPI spec parsing module (`openapi.rs`) with search, explain, and request building
-- Vendored Onshape OpenAPI spec (`crates/onshape-mcp-io/onshape-openapi.json`) embedded at compile time
-- Effects-as-data pattern for `onshape_api_call` (`ToolResult::OnshapeApiRequest`)
+- Added request-header support to `onshape_api_call`, including explicit
+  `Accept` headers and required OpenAPI header parameters
+- Added binary API responses with base64-encoded body metadata
+- Added public sans-I/O Rust helpers for configuration, translations, external
+  data downloads, and Part Studio or Assembly glTF/STEP exports
+- Added the standalone `onshape-openapi` crate for OpenAPI search, explanation,
+  and request building
+
+### Changed
+
+- Direct OAuth with a user-owned Onshape application is now the default; proxy
+  login requires an explicit self-hosted proxy URL, and this project no longer
+  offers public hosted MCP or OAuth proxy services
+- OAuth and configuration storage now honors absolute XDG paths and consistently
+  uses `%LOCALAPPDATA%` for Windows token storage
+- Public Rust HTTP boundaries now use `http` crate types and preserve response
+  headers and raw bytes
+- Upgraded to rmcp 2.2 and the MCP 2025-11-25 model API; public Rust resource
+  and content types now use `Resource` and `ContentBlock`
+- Updated the embedded Onshape OpenAPI specification and FeatureScript error
+  descriptions, including verified 3MF translation parameters
+
+### Fixed
+
+- Made OAuth token writes atomic and serialized, preventing refresh, login, and
+  file-watcher races; incomplete token responses are now rejected
+- Fixed dynamic calls that omitted OpenAPI path-level parameters
+- Fixed parameterized JSON and binary content-type handling and binary endpoint
+  content negotiation
+- Updated `rustls-webpki` to address RustSec advisories
+
+### Migration Notes
+
+- Replace `onshape-mcp auth login --direct` with `onshape-mcp auth login`
+- For proxy login, pass an explicit self-hosted URL with
+  `onshape-mcp auth login --proxy-url https://your-proxy.example`; remote proxy
+  URLs must use HTTPS
+- Calls to `onshape_auth_login` now default to direct mode and therefore require
+  nonblank `client_id` and `client_secret` values; proxy calls must explicitly
+  set `mode` to `"proxy"` and provide a nonblank self-hosted `proxy_url`
+- OpenCode now lists direct OAuth first and prompts for a user-owned client ID
+  and secret; its proxy option requires an explicit self-hosted URL and has no
+  project-provided default
+- Remove configurations that reference the former hosted MCP server or public
+  OAuth proxy
+- Windows users may need to authenticate again because tokens are now read from
+  `%LOCALAPPDATA%\onshape-mcp\tokens.json` rather than `%APPDATA%`
+- Rust consumers of `OAuthTokenData` must remove the former `client_id`,
+  `client_secret`, and `proxy_url` fields from struct literals and field access;
+  persisted MCP token files retain those metadata keys, but there is no public
+  replacement metadata type
+- Import `default_data_dir` and `default_token_file_path` from
+  `onshape_mcp_io::oauth` instead of `onshape_client_core::oauth`
+- `OpenApiSpec::build_request` moved to `onshape_openapi` and now takes an
+  `&http::HeaderMap` argument between `query_params` and `body`; callers without
+  headers can pass `&HeaderMap::new()`
+- `IoResult::ApiResponse` now includes `headers: &[(String, String)]`, and its
+  `body` changed from `&str` to `&[u8]`; constructors and exhaustive patterns
+  must add `headers`, and text bodies must be converted to bytes
+- `process_api_response` changed from `(status, body: &str)` to
+  `(status, headers: &[(String, String)], body: &[u8])`; pass `&[]` when no
+  headers are available and preserve raw response bytes
+- Rust consumers should use `http::Method`, `http::StatusCode`, and
+  `http::HeaderMap`, handle `ApiRequest.headers`, and read response bodies with
+  `ResponseBody::as_bytes()` or `ResponseBody::text()`
+- Import OpenAPI helpers from `onshape_openapi` instead of
+  `onshape_mcp_core::openapi`, and update rmcp resource/content consumers to
+  `Resource` and `ContentBlock`

--- a/docs/src/project/ci.md
+++ b/docs/src/project/ci.md
@@ -170,7 +170,8 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 │    build:                                                         │
 │      uses: ./.github/workflows/reflow-release-build.yml          │
 │                                                                   │
-│    checks: (needs: pre-commit, rust, coverage, npm)               │
+│    checks: (needs: mise, pre-commit, rust, coverage, npm,         │
+│                   version, error-enums)                            │
 │      re-actors/alls-green — gates release jobs on all quality     │
 │      checks passing                                               │
 │                                                                   │

--- a/docs/src/project/npm-wrapper.md
+++ b/docs/src/project/npm-wrapper.md
@@ -142,12 +142,14 @@ For Rust-side stdio buffering considerations, see [#37](https://github.com/alten
 
 ## Versioning Strategy
 
-All npm packages use **lockstep versioning** with the Cargo version:
+All release packages in `npm/` use **lockstep versioning** with the Cargo version:
 
 - Cargo.toml version: `0.1.0`
 - All npm packages: `0.1.0`
 
-This ensures consistency and simplifies the release process.
+This ensures consistency and simplifies the release process. The private,
+independently versioned `workers/oauth-proxy` package is not an npm release
+artifact and is intentionally excluded from version discovery.
 
 ### Enforcement
 

--- a/docs/src/project/release.md
+++ b/docs/src/project/release.md
@@ -49,7 +49,12 @@ All steps run on every trigger. The `release-config` job determines whether each
 
 The authoritative version is `[workspace.package].version` in the root `Cargo.toml`.
 All crate `Cargo.toml` files inherit this version via `version.workspace = true`.
-The `[workspace.dependencies]` internal crate version entries, `Cargo.lock`, and all npm `package.json` files are synced to this version via `scripts/sync-versions.js`, enforced by a pre-commit hook.
+Every path-based `[workspace.dependencies]` version, `Cargo.lock`, and every npm
+package and lockfile in an immediate package directory under `npm/` is discovered
+and synced to this version via `scripts/sync-versions.js`. The private
+`workers/oauth-proxy` package is independently versioned and intentionally
+excluded from discovery. The pre-commit hook auto-syncs relevant manifest edits;
+CI runs check mode on every PR and is the universal enforcement layer.
 
 ### Staging Version Format
 
@@ -196,7 +201,8 @@ Steps:
 4. Creates branch `release/v{version}`
 5. Updates `[workspace.package].version` in root `Cargo.toml`
 6. Runs `node scripts/sync-versions.js` (propagates to workspace deps, Cargo.lock, all npm packages)
-7. Commits, pushes, opens PR with `enqueue` label
+7. Moves the current `Unreleased` changelog content into a dated release section
+8. Commits, pushes, opens PR with `enqueue` label
 
 ### Auto-Tag Workflow (`reflow-tag-release.yml`)
 
@@ -204,12 +210,18 @@ A reusable workflow called from `ci.yml` as the `tag-release` job, gated on `nee
 
 The `tag-release` job only runs on pushes to `main` (`if: github.ref == 'refs/heads/main'`). Outputs a `tagged` boolean so downstream jobs know whether a tag was created.
 
+Immediately before creating a new stable tag, the workflow independently
+extracts the matching curated changelog section. A stable version that reaches
+`main` without finalized release notes therefore fails before tag creation,
+regardless of its source branch.
+
 Steps:
 
 1. Read version from `Cargo.toml` (via `cargo metadata`)
 2. If version contains `-` → exit (pre-release / dev version, not a release commit)
 3. If tag `v{version}` already exists → exit (idempotent)
-4. Create and push tag `v{version}` (triggers `ci.yml` publish pipeline)
+4. Require an extractable changelog section for `v{version}`
+5. Create and push tag `v{version}` (triggers `ci.yml` publish pipeline)
 
 ### Post-Release Workflow (`reflow-post-release.yml`)
 
@@ -287,7 +299,12 @@ build ────────────────┼──► release-npm
                             build, release-npm, cargo-publish)
 ```
 
-All quality jobs (`pre-commit`, `rust`, `coverage`, `npm`) must pass the `checks` gate before any publishing can begin. `build` and `version` start immediately in parallel. `release-config` depends on `version` and makes a single mode decision. `cargo-publish` and `release-npm` both depend on `release-config` and `checks`; `release-npm` also depends on `build`. `publish-release` waits for everything.
+All validation jobs aggregated by `checks`, including version synchronization,
+must pass before tagging or publishing can begin. `build` and `version` start
+immediately in parallel. `release-config` depends on `version` and makes a single
+mode decision. `cargo-publish` and `release-npm` both depend on `release-config`
+and `checks`; `release-npm` also depends on `build`. `publish-release` waits for
+everything.
 
 ### Release-Config Job
 
@@ -319,6 +336,12 @@ Packages release archives and creates a GitHub Release. Parameterized by `publis
 
 ### GitHub Release Contents
 
+The curated changelog section for the release is prepended to GitHub-generated
+release notes. This keeps material dependency changes represented in the curated
+notes even when their Renovate pull requests are excluded from generated notes.
+Generated release notes include all merged pull requests except those authored
+by `altendky-renovate[bot]`, as configured in `.github/release.yml`.
+
 | Asset | Description |
 | ----- | ----------- |
 | Platform archives (5) | Binary + `LICENSE-MIT` + `LICENSE-APACHE` per platform |
@@ -335,41 +358,19 @@ Artifacts are shared across workflow runs via GitHub Actions upload/download.
 
 ## Crate Naming and Publish Order
 
-All workspace crates are published to crates.io.
-The naming follows Rust ecosystem conventions: `-proto` suffix for sans-IO protocol crates (following the pattern established by `quinn-proto`, `hickory-proto`, etc.), with the clean base name for the IO layer.
+All publishable workspace crates are released to crates.io. The publish script
+uses Cargo metadata to discover the current crate set and topologically sort its
+internal dependencies, so the order does not require manual maintenance.
 
-Crate names are scoped under `onshape-mcp-*` to group them on crates.io (which has no organization or namespace mechanism — all crate names share a flat global namespace).
-If the client crates mature into a general-purpose Onshape SDK, they can be renamed to drop the `mcp` scoping.
+The current workspace crates are:
 
-### Naming Scheme
-
-| Side | Sans-IO | IO |
-| ---- | ------- | -- |
-| MCP server | `onshape-mcp-proto` | `onshape-mcp` (lib.rs + main.rs) |
-| Onshape API | `onshape-mcp-client-proto` | `onshape-mcp-client` |
-
-The MCP server binary and IO library are merged into a single crate (`onshape-mcp`) following the quinn model — `quinn-proto` for the sans-IO layer, `quinn` for the IO layer and public API.
-Rust crates can have both `lib.rs` and `main.rs`; the library is usable as a dependency while `cargo install` builds the binary.
-
-The tracing crates are standalone (not Onshape-specific).
-See [Open Questions](open-questions.md#tracing-crate-naming) for the naming decision.
-
-### Full Crate List
-
-Publish order follows the dependency chain (leaves first):
-
-| Order | Crate | Current name | Description |
-| ----- | ----- | ------------ | ----------- |
-| 1 | `tracing-*-macros` | `tracing-sansio-macros` | Proc-macro for tracing capture (name TBD) |
-| 2 | `tracing-*` | `tracing-sansio` | Sans-IO tracing capture library (name TBD) |
-| 3 | `onshape-mcp-client-proto` | `onshape-client-core` | Sans-IO Onshape API types/logic |
-| 4 | `onshape-mcp-client` | (planned) | Onshape API HTTP client |
-| 5 | `onshape-mcp-proto` | `onshape-mcp-core` | Sans-IO MCP server protocol logic |
-| 6 | `onshape-mcp` | `onshape-mcp` + `onshape-mcp-io` | MCP server IO + binary (merged) |
-
-The exact order may vary as dependencies evolve.
-Only crates that exist and are workspace members at the time of release are published.
-The rename from current names to target names is a prerequisite for the first release.
+- `onshape-client-core`
+- `onshape-client-io`
+- `onshape-openapi`
+- `onshape-mcp-resources`
+- `onshape-mcp-core`
+- `onshape-mcp-io`
+- `onshape-mcp`
 
 ## Checksums
 

--- a/mise.toml
+++ b/mise.toml
@@ -86,6 +86,9 @@ sed -i "s/^version = \".*\"/version = \"${version}\"/" Cargo.toml
 # Propagate to all workspace deps, Cargo.lock, npm packages
 node scripts/sync-versions.js
 
+# Move Unreleased notes into the dated release section
+node scripts/release-changelog.js finalize "$version"
+
 # Commit and push
 git add -A
 git commit -m "Release v${version}"

--- a/scripts/release-changelog.js
+++ b/scripts/release-changelog.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.join(__dirname, "..");
+const CHANGELOG_PATH = path.join(
+  ROOT,
+  "docs",
+  "src",
+  "project",
+  "changelog.md",
+);
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function validateDate(date) {
+  if (!DATE_PATTERN.test(date)) {
+    return false;
+  }
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return (
+    !Number.isNaN(parsed.valueOf()) &&
+    parsed.toISOString().slice(0, 10) === date
+  );
+}
+
+function currentLocalDate() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseChangelog(content) {
+  const headingPattern = /^## \[([^\]\r\n]+)\](?: - ([^\r\n]+))?\r?$/gm;
+  const candidateHeadings = content.match(/^## \[.*$/gm) ?? [];
+  const matches = [...content.matchAll(headingPattern)];
+  if (matches.length !== candidateHeadings.length) {
+    throw new Error("Malformed changelog release heading");
+  }
+  if (matches.length === 0) {
+    throw new Error("No changelog release headings found");
+  }
+
+  const seen = new Set();
+  const sections = matches.map((match, index) => {
+    const name = match[1];
+    const date = match[2];
+    if (seen.has(name)) {
+      throw new Error(`Duplicate changelog section: ${name}`);
+    }
+    seen.add(name);
+
+    if (name === "Unreleased") {
+      if (date !== undefined) {
+        throw new Error("Unreleased changelog section must not have a date");
+      }
+    } else {
+      if (!SEMVER_PATTERN.test(name)) {
+        throw new Error(`Invalid changelog version heading: ${name}`);
+      }
+      if (date === undefined || !validateDate(date)) {
+        throw new Error(
+          `Invalid or missing date for changelog version ${name}`,
+        );
+      }
+    }
+
+    const start = match.index;
+    const headingEnd = start + match[0].length;
+    const end = matches[index + 1]?.index ?? content.length;
+    return {
+      name,
+      date,
+      heading: match[0],
+      start,
+      end,
+      body: content.slice(headingEnd, end).trim(),
+    };
+  });
+
+  if (sections[0].name !== "Unreleased") {
+    throw new Error("Unreleased must be the first changelog release section");
+  }
+  return sections;
+}
+
+function finalizeChangelog(content, version, date) {
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+  if (!validateDate(date)) {
+    throw new Error(`Invalid release date: ${date}`);
+  }
+
+  const sections = parseChangelog(content);
+  const unreleased = sections[0];
+  if (sections.some((section) => section.name === version)) {
+    throw new Error(`Changelog section already exists for ${version}`);
+  }
+  if (unreleased.body.length === 0) {
+    throw new Error("Unreleased changelog section is empty");
+  }
+
+  const prefix = content.slice(0, unreleased.start);
+  const suffix = content.slice(unreleased.end).trimStart();
+  let finalized = `${prefix}## [Unreleased]\n\n## [${version}] - ${date}\n\n${unreleased.body}\n`;
+  if (suffix.length > 0) {
+    finalized += `\n${suffix}`;
+  }
+  if (!finalized.endsWith("\n")) {
+    finalized += "\n";
+  }
+  return finalized;
+}
+
+function extractReleaseSection(content, version, required = true) {
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+  const section = parseChangelog(content).find(
+    (candidate) => candidate.name === version,
+  );
+  if (!section) {
+    if (!required) {
+      return null;
+    }
+    throw new Error(`Missing changelog section for ${version}`);
+  }
+  if (section.body.length === 0) {
+    throw new Error(`Changelog section for ${version} is empty`);
+  }
+  return `${section.heading}\n\n${section.body}\n`;
+}
+
+function main() {
+  const [command, version, ...args] = process.argv.slice(2);
+  if (!command || !version) {
+    throw new Error(
+      "Usage: release-changelog.js <finalize|extract|validate-if-present> <version> [--date YYYY-MM-DD]",
+    );
+  }
+
+  const content = fs.readFileSync(CHANGELOG_PATH, "utf8");
+  if (command === "finalize") {
+    const dateIndex = args.indexOf("--date");
+    const date =
+      dateIndex === -1 ? currentLocalDate() : args[dateIndex + 1];
+    if (!date) {
+      throw new Error("--date requires a YYYY-MM-DD value");
+    }
+    fs.writeFileSync(CHANGELOG_PATH, finalizeChangelog(content, version, date));
+    console.log(`Finalized changelog for ${version} (${date})`);
+    return;
+  }
+  if (command === "extract") {
+    process.stdout.write(extractReleaseSection(content, version));
+    return;
+  }
+  if (command === "validate-if-present") {
+    const section = extractReleaseSection(content, version, false);
+    console.log(
+      section
+        ? `Validated changelog section for ${version}`
+        : `No finalized changelog section for ${version}`,
+    );
+    return;
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  extractReleaseSection,
+  finalizeChangelog,
+  parseChangelog,
+};

--- a/scripts/release-changelog.test.js
+++ b/scripts/release-changelog.test.js
@@ -1,0 +1,91 @@
+"use strict";
+
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+
+const {
+  extractReleaseSection,
+  finalizeChangelog,
+  parseChangelog,
+} = require("./release-changelog.js");
+
+const PREAMBLE = "# Changelog\n\nProject changes.\n\n";
+
+describe("release changelog", () => {
+  it("moves Unreleased content into a dated release section", () => {
+    const input = `${PREAMBLE}## [Unreleased]\n\n### Added\n\n- New feature\n`;
+    const output = finalizeChangelog(input, "0.5.0", "2026-07-21");
+
+    assert.match(output, /## \[Unreleased\]\n\n## \[0\.5\.0\] - 2026-07-21/);
+    assert.strictEqual(parseChangelog(output)[0].body, "");
+    assert.strictEqual(
+      extractReleaseSection(output, "0.5.0"),
+      "## [0.5.0] - 2026-07-21\n\n### Added\n\n- New feature\n",
+    );
+  });
+
+  it("preserves older release sections", () => {
+    const input = `${PREAMBLE}## [Unreleased]\n\n- New\n\n## [0.4.0] - 2026-06-01\n\n- Old\n`;
+    const output = finalizeChangelog(input, "0.5.0", "2026-07-21");
+
+    assert.match(output, /## \[0\.4\.0\] - 2026-06-01\n\n- Old/);
+  });
+
+  it("rejects empty, duplicate, and pre-finalized state", () => {
+    assert.throws(
+      () =>
+        finalizeChangelog(
+          `${PREAMBLE}## [Unreleased]\n`,
+          "0.5.0",
+          "2026-07-21",
+        ),
+      /Unreleased changelog section is empty/,
+    );
+    assert.throws(
+      () =>
+        finalizeChangelog(
+          `${PREAMBLE}## [Unreleased]\n\n- A\n\n## [Unreleased]\n\n- B\n`,
+          "0.5.0",
+          "2026-07-21",
+        ),
+      /Duplicate changelog section: Unreleased/,
+    );
+    assert.throws(
+      () =>
+        finalizeChangelog(
+          `${PREAMBLE}## [Unreleased]\n\n- A\n\n## [0.5.0] - 2026-07-20\n\n- Existing\n`,
+          "0.5.0",
+          "2026-07-21",
+        ),
+      /Changelog section already exists for 0.5.0/,
+    );
+  });
+
+  it("rejects malformed headings and dates", () => {
+    assert.throws(
+      () =>
+        parseChangelog(
+          `${PREAMBLE}## [Unreleased]\n\n- A\n\n## [0.4.0] soon\n`,
+        ),
+      /Malformed changelog release heading/,
+    );
+    assert.throws(
+      () =>
+        finalizeChangelog(
+          `${PREAMBLE}## [Unreleased]\n\n- A\n`,
+          "0.5.0",
+          "2026-02-30",
+        ),
+      /Invalid release date/,
+    );
+  });
+
+  it("allows validation when the target section is not finalized yet", () => {
+    const input = `${PREAMBLE}## [Unreleased]\n\n- Pending\n`;
+    assert.strictEqual(extractReleaseSection(input, "0.5.0", false), null);
+    assert.throws(
+      () => extractReleaseSection(input, "0.5.0"),
+      /Missing changelog section/,
+    );
+  });
+});

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -22,25 +22,6 @@ const ROOT = path.join(__dirname, "..");
 const ROOT_CARGO_TOML = path.join(ROOT, "Cargo.toml");
 const NPM_DIR = path.join(ROOT, "npm");
 
-const NPM_PACKAGES = [
-  "onshape-mcp",
-  "opencode-auth",
-  "linux-x64",
-  "linux-arm64",
-  "darwin-x64",
-  "darwin-arm64",
-  "win32-x64",
-];
-
-// Internal crates whose version entries in [workspace.dependencies] must match.
-const INTERNAL_CRATES = [
-  "onshape-client-core",
-  "onshape-client-io",
-  "onshape-mcp-core",
-  "onshape-mcp-io",
-  "onshape-mcp-resources",
-];
-
 // ---------------------------------------------------------------------------
 // Cargo version helpers
 // ---------------------------------------------------------------------------
@@ -59,8 +40,46 @@ function getWorkspaceVersion() {
 }
 
 /**
- * For each internal crate in [workspace.dependencies], extract the current
- * version string from its inline table.
+ * Find every path-based dependency in [workspace.dependencies].
+ *
+ * The workspace uses inline tables for local dependencies so they remain
+ * publishable with a registry version fallback.
+ */
+function getPathWorkspaceDependencies(content) {
+  const section = content.match(
+    /\[workspace\.dependencies\]([\s\S]*?)(?=\n\[|$)/,
+  );
+  if (!section) {
+    throw new Error(
+      `Could not find [workspace.dependencies] in ${ROOT_CARGO_TOML}`,
+    );
+  }
+
+  const dependencies = [];
+  const entryPattern = /^\s*([A-Za-z0-9_-]+)\s*=\s*\{([^}]*)\}/gm;
+  let match;
+  while ((match = entryPattern.exec(section[1])) !== null) {
+    if (!/(?:^|,)\s*path\s*=\s*"[^"]+"/.test(match[2])) {
+      continue;
+    }
+    const version = match[2].match(/(?:^|,)\s*version\s*=\s*"([^"]+)"/);
+    dependencies.push({
+      crate: match[1],
+      currentVersion: version?.[1] ?? "<not found>",
+    });
+  }
+
+  if (dependencies.length === 0) {
+    throw new Error(
+      `No path-based dependencies found in [workspace.dependencies] in ${ROOT_CARGO_TOML}`,
+    );
+  }
+  return dependencies;
+}
+
+/**
+ * For each path-based dependency in [workspace.dependencies], extract the
+ * current version string from its inline table.
  *
  * Returns an array of { crate, currentVersion, expected } objects for mismatches,
  * or an empty array if all match.
@@ -69,26 +88,13 @@ function checkWorkspaceDepsVersions(expectedVersion) {
   const content = fs.readFileSync(ROOT_CARGO_TOML, "utf8");
   const mismatches = [];
 
-  for (const crate of INTERNAL_CRATES) {
-    // Match: crate-name = { path = "...", version = "X.Y.Z" }
-    // The version field may appear before or after path.
-    const pattern = new RegExp(
-      `^(${escapeRegex(crate)}\\s*=\\s*\\{[^}]*)version\\s*=\\s*"([^"]+)"`,
-      "m",
-    );
-    const match = content.match(pattern);
-    if (!match) {
+  for (const { crate, currentVersion } of getPathWorkspaceDependencies(
+    content,
+  )) {
+    if (currentVersion !== expectedVersion) {
       mismatches.push({
         crate,
-        currentVersion: "<not found>",
-        expected: expectedVersion,
-      });
-      continue;
-    }
-    if (match[2] !== expectedVersion) {
-      mismatches.push({
-        crate,
-        currentVersion: match[2],
+        currentVersion,
         expected: expectedVersion,
       });
     }
@@ -98,36 +104,49 @@ function checkWorkspaceDepsVersions(expectedVersion) {
 }
 
 /**
- * Update the version field for each internal crate in [workspace.dependencies]
- * to match the workspace version. Returns true if any changes were made.
+ * Update the version field for each path-based dependency in
+ * [workspace.dependencies] to match the workspace version.
  */
 function updateWorkspaceDepsVersions(expectedVersion) {
   let content = fs.readFileSync(ROOT_CARGO_TOML, "utf8");
   let changed = false;
-  const missingCrates = [];
+  const dependencies = getPathWorkspaceDependencies(content);
+  const sectionPattern = /\[workspace\.dependencies\]([\s\S]*?)(?=\n\[|$)/;
+  let section = content.match(sectionPattern)[0];
 
-  for (const crate of INTERNAL_CRATES) {
-    // Replace version = "..." within the inline table for this crate.
+  for (const { crate, currentVersion } of dependencies) {
     const pattern = new RegExp(
-      `^(${escapeRegex(crate)}\\s*=\\s*\\{[^}]*version\\s*=\\s*)"([^"]+)"`,
+      `^(\\s*${escapeRegex(crate)}\\s*=\\s*\\{)([^}]*)(\\})`,
       "m",
     );
-    const match = content.match(pattern);
-    if (!match) {
-      missingCrates.push(crate);
-      continue;
-    }
-    if (match[2] !== expectedVersion) {
-      content = content.replace(pattern, `$1"${expectedVersion}"`);
+    if (currentVersion !== expectedVersion) {
+      section = section.replace(pattern, (_entry, start, fields, end) => {
+        if (/(?:^|,)\s*version\s*=\s*"[^"]+"/.test(fields)) {
+          fields = fields.replace(
+            /((?:^|,)\s*version\s*=\s*)"[^"]+"/,
+            `$1"${expectedVersion}"`,
+          );
+        } else {
+          const trailingWhitespace = fields.match(/\s*$/)?.[0] ?? "";
+          const trimmedFields = fields.slice(
+            0,
+            fields.length - trailingWhitespace.length,
+          );
+          const separator = trimmedFields.endsWith(",") ? "" : ",";
+          fields = `${trimmedFields}${separator} version = "${expectedVersion}"${trailingWhitespace}`;
+        }
+        return `${start}${fields}${end}`;
+      });
       changed = true;
     }
   }
 
   if (changed) {
+    content = content.replace(sectionPattern, section);
     fs.writeFileSync(ROOT_CARGO_TOML, content);
   }
 
-  return { changed, missingCrates };
+  return changed;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,6 +203,43 @@ function writePackageJson(pkgPath, pkg) {
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 }
 
+function getNpmPackageDirectories(npmDir = NPM_DIR) {
+  const packageDirectories = fs
+    .readdirSync(npmDir, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        fs.existsSync(path.join(npmDir, entry.name, "package.json")),
+    )
+    .map((entry) => entry.name)
+    .sort();
+
+  if (packageDirectories.length === 0) {
+    throw new Error(`No npm package.json files found under ${npmDir}`);
+  }
+  return packageDirectories;
+}
+
+function checkNpmPublishInventory(publishedPackages, npmDir = NPM_DIR) {
+  const discovered = new Set(getNpmPackageDirectories(npmDir));
+  const published = new Set(publishedPackages);
+  const mismatches = [];
+
+  for (const packageName of [...discovered].sort()) {
+    if (!published.has(packageName)) {
+      mismatches.push(`npm/${packageName} is not in the publish inventory`);
+    }
+  }
+  for (const packageName of [...published].sort()) {
+    if (!discovered.has(packageName)) {
+      mismatches.push(
+        `publish inventory package npm/${packageName} does not exist`,
+      );
+    }
+  }
+  return mismatches;
+}
+
 function updatePackageVersion(pkgPath, version) {
   const pkg = readPackageJson(pkgPath);
   let changed = false;
@@ -211,29 +267,58 @@ function checkPackageVersion(pkgPath, version) {
   return mismatches;
 }
 
-function checkLockfileVersion(lockPath, version) {
-  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
-  const mismatches = [];
+function isNonArrayObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
-  if (!lock.lockfileVersion || lock.lockfileVersion < 2) {
-    mismatches.push(
-      `lockfileVersion: ${lock.lockfileVersion ?? "missing"} (expected >= 2)`,
+function validateNpmLockfile(lock) {
+  if (!isNonArrayObject(lock)) {
+    return ["top-level value must be a non-array object"];
+  }
+
+  const errors = [];
+  if (!Number.isInteger(lock.lockfileVersion) || lock.lockfileVersion < 2) {
+    errors.push(
+      `lockfileVersion: ${lock.lockfileVersion ?? "missing"} (expected an integer >= 2)`,
     );
+  }
+  if (!isNonArrayObject(lock.packages)) {
+    errors.push("packages must be a non-array object");
+  } else if (!isNonArrayObject(lock.packages[""])) {
+    errors.push('packages[""] must be a non-array object');
+  }
+  return errors;
+}
+
+function readNpmLockfile(lockPath) {
+  try {
+    return { lock: JSON.parse(fs.readFileSync(lockPath, "utf8")), errors: [] };
+  } catch (err) {
+    return { lock: null, errors: [`invalid JSON: ${err.message}`] };
+  }
+}
+
+function checkLockfileVersion(lockPath, version) {
+  const { lock, errors } = readNpmLockfile(lockPath);
+  const mismatches = [...errors];
+  if (errors.length > 0) {
+    return mismatches;
+  }
+
+  mismatches.push(...validateNpmLockfile(lock));
+  if (mismatches.length > 0) {
+    return mismatches;
   }
 
   if (lock.version !== version) {
     mismatches.push(`version: ${lock.version} (expected ${version})`);
   }
 
-  const rootPkg = lock.packages?.[""];
-  if (!rootPkg || typeof rootPkg !== "object") {
-    mismatches.push('packages[""] entry is missing');
-  } else {
-    if (rootPkg.version !== version) {
-      mismatches.push(
-        `packages[""].version: ${rootPkg.version} (expected ${version})`,
-      );
-    }
+  const rootPkg = lock.packages[""];
+  if (rootPkg.version !== version) {
+    mismatches.push(
+      `packages[""].version: ${rootPkg.version} (expected ${version})`,
+    );
   }
 
   return mismatches;
@@ -244,7 +329,19 @@ function updateNpmLockfile(pkgDir, version) {
   const lockRelPath = path.relative(ROOT, lockPath);
   console.log(`Updating ${lockRelPath}...`);
 
-  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  const { lock, errors: readErrors } = readNpmLockfile(lockPath);
+  const errors = [...readErrors];
+  if (readErrors.length === 0) {
+    errors.push(...validateNpmLockfile(lock));
+  }
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(`ERROR: ${lockRelPath}: ${error}`);
+    }
+    return false;
+  }
+
+  const rootPkg = lock.packages[""];
   let changed = false;
 
   if (lock.version !== version) {
@@ -252,8 +349,7 @@ function updateNpmLockfile(pkgDir, version) {
     changed = true;
   }
 
-  const rootPkg = lock.packages?.[""];
-  if (rootPkg && rootPkg.version !== version) {
+  if (rootPkg.version !== version) {
     rootPkg.version = version;
     changed = true;
   }
@@ -305,20 +401,10 @@ function main() {
       console.log("OK: [workspace.dependencies] internal crate versions");
     }
   } else {
-    const { changed, missingCrates } = updateWorkspaceDepsVersions(version);
-    if (missingCrates.length > 0) {
-      for (const crate of missingCrates) {
-        console.error(
-          `MISMATCH: [workspace.dependencies] ${crate}: <not found> (expected ${version})`,
-        );
-      }
-      hasErrors = true;
-    }
+    const changed = updateWorkspaceDepsVersions(version);
     if (changed) {
-      console.log(
-        "UPDATED: [workspace.dependencies] internal crate versions",
-      );
-    } else if (missingCrates.length === 0) {
+      console.log("UPDATED: [workspace.dependencies] internal crate versions");
+    } else {
       console.log(
         "OK: [workspace.dependencies] internal crate versions (no changes)",
       );
@@ -347,7 +433,8 @@ function main() {
 
   // --- npm package.json files ---
   console.log("=== npm packages ===");
-  for (const pkg of NPM_PACKAGES) {
+  const npmPackages = getNpmPackageDirectories();
+  for (const pkg of npmPackages) {
     const pkgPath = path.join(NPM_DIR, pkg, "package.json");
 
     if (!fs.existsSync(pkgPath)) {
@@ -378,31 +465,35 @@ function main() {
   }
   console.log();
 
-  // --- npm package-lock.json ---
-  console.log("=== npm lockfile ===");
-  const mainPkgDir = path.join(NPM_DIR, "onshape-mcp");
-  const lockPath = path.join(mainPkgDir, "package-lock.json");
-
-  if (checkOnly) {
+  // --- npm package-lock.json files ---
+  console.log("=== npm lockfiles ===");
+  for (const pkg of npmPackages) {
+    const pkgDir = path.join(NPM_DIR, pkg);
+    const lockPath = path.join(pkgDir, "package-lock.json");
     if (!fs.existsSync(lockPath)) {
-      console.error("ERROR: npm/onshape-mcp/package-lock.json not found");
-      hasErrors = true;
-    } else {
+      continue;
+    }
+
+    if (checkOnly) {
       const lockMismatches = checkLockfileVersion(lockPath, version);
       if (lockMismatches.length > 0) {
-        console.error("MISMATCH: npm/onshape-mcp/package-lock.json");
+        console.error(`MISMATCH: npm/${pkg}/package-lock.json`);
         for (const m of lockMismatches) {
           console.error(`  - ${m}`);
         }
         hasErrors = true;
       } else {
-        console.log("OK: npm/onshape-mcp/package-lock.json");
+        console.log(`OK: npm/${pkg}/package-lock.json`);
       }
-    }
-  } else {
-    if (!updateNpmLockfile(mainPkgDir, version)) {
+    } else if (!updateNpmLockfile(pkgDir, version)) {
       hasErrors = true;
     }
+  }
+
+  const mainLockPath = path.join(NPM_DIR, "onshape-mcp", "package-lock.json");
+  if (!fs.existsSync(mainLockPath)) {
+    console.error("ERROR: npm/onshape-mcp/package-lock.json not found");
+    hasErrors = true;
   }
 
   if (hasErrors) {
@@ -410,10 +501,40 @@ function main() {
     if (checkOnly) {
       console.error("Version mismatch detected. Run without --check to fix.");
     } else {
-      console.error("Version sync failed. See errors above and re-run after fixes.");
+      console.error(
+        "Version sync failed. See errors above and re-run after fixes.",
+      );
     }
     process.exit(1);
   }
 }
 
-main();
+if (require.main === module) {
+  const inventoryFlag = "--check-npm-publish-inventory";
+  const inventoryIndex = process.argv.indexOf(inventoryFlag);
+  if (inventoryIndex !== -1) {
+    const publishedPackages = process.argv.slice(inventoryIndex + 1);
+    if (publishedPackages.length === 0) {
+      console.error(`ERROR: ${inventoryFlag} requires package names`);
+      process.exit(1);
+    }
+    const mismatches = checkNpmPublishInventory(publishedPackages);
+    if (mismatches.length > 0) {
+      for (const mismatch of mismatches) {
+        console.error(`ERROR: ${mismatch}`);
+      }
+      process.exit(1);
+    }
+    console.log("OK: npm publish inventory matches discovered packages");
+  } else {
+    main();
+  }
+}
+
+module.exports = {
+  checkLockfileVersion,
+  checkNpmPublishInventory,
+  getNpmPackageDirectories,
+  updateNpmLockfile,
+  validateNpmLockfile,
+};

--- a/scripts/sync-versions.test.js
+++ b/scripts/sync-versions.test.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const {
+  checkLockfileVersion,
+  checkNpmPublishInventory,
+  getNpmPackageDirectories,
+  updateNpmLockfile,
+  validateNpmLockfile,
+} = require("./sync-versions.js");
+
+function validLockfile(overrides = {}) {
+  return {
+    version: "0.5.0",
+    lockfileVersion: 3,
+    packages: { "": { version: "0.5.0" } },
+    ...overrides,
+  };
+}
+
+function temporaryDirectory(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "sync-versions-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+describe("npm lockfile validation", () => {
+  it("requires object containers", () => {
+    const cases = [
+      [[], "top-level value must be a non-array object"],
+      [null, "top-level value must be a non-array object"],
+      [validLockfile({ packages: [] }), "packages must be a non-array object"],
+      [
+        validLockfile({ packages: null }),
+        "packages must be a non-array object",
+      ],
+      [
+        validLockfile({ packages: { "": [] } }),
+        'packages[""] must be a non-array object',
+      ],
+      [
+        validLockfile({ packages: { "": null } }),
+        'packages[""] must be a non-array object',
+      ],
+    ];
+
+    for (const [lockfile, expected] of cases) {
+      assert.ok(validateNpmLockfile(lockfile).includes(expected));
+    }
+  });
+
+  it("requires an integer lockfileVersion of at least 2", () => {
+    assert.deepStrictEqual(validateNpmLockfile(validLockfile()), []);
+    assert.deepStrictEqual(
+      validateNpmLockfile(validLockfile({ lockfileVersion: 2 })),
+      [],
+    );
+
+    for (const lockfileVersion of [1, 2.5, "3", null]) {
+      assert.ok(
+        validateNpmLockfile(validLockfile({ lockfileVersion })).some((error) =>
+          error.includes("expected an integer >= 2"),
+        ),
+      );
+    }
+  });
+
+  it("reports invalid JSON in check mode", (t) => {
+    const lockPath = path.join(temporaryDirectory(t), "package-lock.json");
+    fs.writeFileSync(lockPath, "{");
+
+    assert.match(checkLockfileVersion(lockPath, "0.5.0")[0], /^invalid JSON:/);
+  });
+
+  it("does not modify malformed lockfiles in update mode", (t) => {
+    const packageDirectory = temporaryDirectory(t);
+    const lockPath = path.join(packageDirectory, "package-lock.json");
+    const malformed = JSON.stringify(validLockfile({ packages: { "": [] } }));
+    fs.writeFileSync(lockPath, malformed);
+
+    const errors = [];
+    const originalError = console.error;
+    const originalLog = console.log;
+    console.error = (...args) => errors.push(args.join(" "));
+    console.log = () => {};
+    try {
+      assert.strictEqual(updateNpmLockfile(packageDirectory, "0.6.0"), false);
+    } finally {
+      console.error = originalError;
+      console.log = originalLog;
+    }
+
+    assert.strictEqual(fs.readFileSync(lockPath, "utf8"), malformed);
+    assert.ok(
+      errors.some((error) => error.includes("must be a non-array object")),
+    );
+  });
+});
+
+describe("npm package discovery", () => {
+  it("discovers npm packages dynamically without including the worker", (t) => {
+    const root = temporaryDirectory(t);
+    const npmDirectory = path.join(root, "npm");
+    for (const packageName of ["zeta", "alpha"]) {
+      const packageDirectory = path.join(npmDirectory, packageName);
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(path.join(packageDirectory, "package.json"), "{}\n");
+    }
+    fs.mkdirSync(path.join(npmDirectory, "not-a-package"));
+
+    const workerDirectory = path.join(root, "workers", "oauth-proxy");
+    fs.mkdirSync(workerDirectory, { recursive: true });
+    fs.writeFileSync(path.join(workerDirectory, "package.json"), "{}\n");
+
+    assert.deepStrictEqual(getNpmPackageDirectories(npmDirectory), [
+      "alpha",
+      "zeta",
+    ]);
+    assert.deepStrictEqual(
+      checkNpmPublishInventory(["alpha", "zeta"], npmDirectory),
+      [],
+    );
+    assert.deepStrictEqual(
+      checkNpmPublishInventory(["alpha", "missing"], npmDirectory),
+      [
+        "npm/zeta is not in the publish inventory",
+        "publish inventory package npm/missing does not exist",
+      ],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- discover and synchronize all path-based Cargo dependencies and npm release packages, including `onshape-openapi`
- validate npm lockfile structure and ensure discovered npm packages match the publish inventory while excluding the independently versioned OAuth worker
- curate the pending v0.5.0 changelog and automate safe Unreleased finalization, extraction, and release-body generation
- require curated notes before release-prep validation, tag creation, registry publication, and GitHub Release creation
- exclude Renovate-authored PRs from generated notes while prepending curated notes so material dependency changes remain visible

## Release Safety

- `mise run release <version>` validates changelog state before moving Unreleased content into a dated release section
- auto-tagging independently requires the matching curated section immediately before creating a stable tag
- GitHub Release creation combines curated notes with `--generate-notes`
- version checks are included in the aggregate release gate
- npm publish inventory is checked against dynamic package discovery

## Verification

- full `pre-commit run --all-files` passed, including formatting, YAML/TOML validation, actionlint, action-validator, shellcheck, Clippy, mdBook, links, and version synchronization
- focused Node regression suites passed: 10 tests covering changelog finalization/extraction, malformed and duplicate changelog state, npm lockfile validation, dynamic discovery, worker exclusion, and publish inventory drift
- `cargo nextest run --all-features`: 584 passed, 0 skipped
- disposable `mise run release 0.5.0` simulation finalized the dated changelog, synchronized all Cargo/npm references, and safely stubbed branch, commit, push, and PR operations
- disposable `cargo package --workspace --locked --allow-dirty` packaged and verified all seven v0.5.0 crates
- simulated npm synchronization updated all seven release packages and retained `workers/oauth-proxy` at its independent version
- check and update modes rejected malformed npm lockfiles without modifying them
- final `git diff --check`, live version synchronization, npm publish-inventory validation, workflow validation, and documentation validation passed
