### PR TITLE
Sync onshape-openapi version

### DIFF
--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -36,6 +36,7 @@ const NPM_PACKAGES = [
 const INTERNAL_CRATES = [
   "onshape-client-core",
   "onshape-client-io",
+  "onshape-openapi",
   "onshape-mcp-core",
   "onshape-mcp-io",
   "onshape-mcp-resources",


### PR DESCRIPTION
## Summary

- add `onshape-openapi` to the existing internal-crate version synchronization list
- ensure the v0.5.0 release bump updates its workspace dependency requirement

## Verification

- `node scripts/sync-versions.js --check`
- `node --check scripts/sync-versions.js`
- focused pre-commit checks for `scripts/sync-versions.js`
- disposable v0.5.0 bump followed by sync and check modes
- confirmed `Cargo.toml`, Cargo metadata, and `Cargo.lock` report `onshape-openapi` at `0.5.0`
