### PR TITLE
Fix post-release payload argument overflow

### DIFF
--- a/.github/workflows/reflow-post-release.yml
+++ b/.github/workflows/reflow-post-release.yml
@@ -79,14 +79,15 @@ jobs:
             -f ref="refs/heads/$branch" \
             -f sha="$base_sha"
 
-          # Base64-encode modified files to temp files (avoids ARG_MAX)
-          additions="[]"
+          # Keep encoded contents out of command arguments to avoid ARG_MAX
+          additions_file="$RUNNER_TEMP/additions.jsonl"
+          : > "$additions_file"
           while IFS= read -r file; do
             base64 -w0 < "$file" > "$RUNNER_TEMP/file.b64"
-            additions=$(jq \
+            jq -n \
               --arg path "$file" \
               --rawfile contents "$RUNNER_TEMP/file.b64" \
-              '. + [{path: $path, contents: $contents}]' <<< "$additions")
+              '{path: $path, contents: $contents}' >> "$additions_file"
           done < <(git diff --name-only)
 
           # Create commit via GraphQL (GitHub signs commits created through this mutation)
@@ -95,7 +96,7 @@ jobs:
             --arg branch "$branch" \
             --arg msg "Start ${dev_version} development" \
             --arg head "$base_sha" \
-            --argjson additions "$additions" \
+            --slurpfile additions "$additions_file" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
               variables: {


### PR DESCRIPTION
## Summary

- write post-release file additions to temporary JSON Lines storage
- load additions with `jq --slurpfile` instead of passing the encoded payload as a command argument
- prevent the post-release workflow from exceeding Linux's per-argument size limit

## Verification

- `pre-commit run --files .github/workflows/reflow-post-release.yml`
- constructed and validated a GraphQL additions payload containing base64 content larger than 128 KiB
