### PR TITLE
Add partial release recovery

### DIFF
--- a/.github/scripts/npm-publish-tarball.sh
+++ b/.github/scripts/npm-publish-tarball.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (($# != 2)); then
+	echo "Usage: $0 <tarball> <dist-tag>" >&2
+	exit 2
+fi
+
+tarball=$1
+dist_tag=$2
+
+if [[ ! -f "$tarball" ]]; then
+	echo "ERROR: Tarball not found: $tarball" >&2
+	exit 1
+fi
+
+metadata=$(npm pack --dry-run --json "$tarball")
+name=$(jq -r '.[0].name // empty' <<<"$metadata")
+version=$(jq -r '.[0].version // empty' <<<"$metadata")
+local_integrity=$(jq -r '.[0].integrity // empty' <<<"$metadata")
+
+if [[ -z "$name" || -z "$version" || -z "$local_integrity" ]]; then
+	echo "ERROR: Could not read package metadata from $tarball" >&2
+	exit 1
+fi
+
+package_version="${name}@${version}"
+
+registry_integrity() {
+	local output
+	local status
+
+	set +e
+	output=$(npm view "$package_version" dist.integrity --json 2>&1)
+	status=$?
+	set -e
+
+	if ((status == 0)); then
+		jq -r 'select(type == "string")' <<<"$output"
+		return 0
+	fi
+
+	if [[ "$output" == *"E404"* ]]; then
+		return 1
+	fi
+
+	printf '%s\n' "$output" >&2
+	return 2
+}
+
+set +e
+remote_integrity=$(registry_integrity)
+lookup_status=$?
+set -e
+
+if ((lookup_status == 0)); then
+	if [[ "$remote_integrity" != "$local_integrity" ]]; then
+		echo "ERROR: Published integrity does not match $tarball for $package_version" >&2
+		echo "  local:  $local_integrity" >&2
+		echo "  remote: $remote_integrity" >&2
+		exit 1
+	fi
+	remote_tag=$(npm view "$name" "dist-tags.$dist_tag" --json | jq -r '.')
+	if [[ "$remote_tag" != "$version" ]]; then
+		echo "ERROR: Dist-tag $dist_tag for $name points to $remote_tag, expected $version" >&2
+		exit 1
+	fi
+	echo "$package_version is already published with matching integrity; skipping."
+	exit 0
+elif ((lookup_status != 1)); then
+	exit "$lookup_status"
+fi
+
+echo "Publishing $tarball as $package_version with dist-tag $dist_tag..."
+set +e
+publish_output=$(npm publish "$tarball" --tag "$dist_tag" --access public 2>&1)
+publish_status=$?
+set -e
+printf '%s\n' "$publish_output"
+
+# npm may lose the response after the registry accepted the package. Polling
+# also handles normal registry propagation and closes the check/publish race.
+for attempt in $(seq 1 15); do
+	set +e
+	remote_integrity=$(registry_integrity)
+	lookup_status=$?
+	set -e
+
+	if ((lookup_status == 0)); then
+		if [[ "$remote_integrity" != "$local_integrity" ]]; then
+			echo "ERROR: Published integrity does not match $tarball for $package_version" >&2
+			exit 1
+		fi
+		remote_tag=$(npm view "$name" "dist-tags.$dist_tag" --json | jq -r '.')
+		if [[ "$remote_tag" == "$version" ]]; then
+			echo "$package_version is available with matching integrity and dist-tag."
+			exit 0
+		fi
+	elif ((lookup_status != 1)); then
+		exit "$lookup_status"
+	fi
+
+	if ((attempt < 15)); then
+		sleep 10
+	fi
+done
+
+if ((publish_status != 0)); then
+	echo "ERROR: npm publish failed for $package_version" >&2
+	exit "$publish_status"
+fi
+
+echo "ERROR: $package_version did not appear with the expected integrity and dist-tag" >&2
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,49 +6,59 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["**"]
+  repository_dispatch:
+    types: [recover-release]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.event_name == 'repository_dispatch' && format('{0}-recovery-{1}', github.workflow_ref, github.event.client_payload.release_tag) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name != 'repository_dispatch' }}
 
 jobs:
   mise:
     name: Mise
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-mise.yml
 
   pre-commit:
     name: Pre-commit
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-pre-commit.yml
 
   rust:
     name: Rust
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-rust.yml
     secrets: inherit
 
   coverage:
     name: Coverage
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-coverage.yml
     permissions:
       id-token: write
 
   npm:
     name: npm
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-npm.yml
     permissions:
       id-token: write
 
   version:
     name: Version
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-release-version.yml
     with:
       git-tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
   build:
     name: Build
+    if: github.event_name != 'repository_dispatch'
     uses: ./.github/workflows/reflow-release-build.yml
 
   error-enums:
     name: Error enums
+    if: github.event_name != 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -59,7 +69,7 @@ jobs:
 
   checks:
     name: checks
-    if: ${{ !cancelled() }}
+    if: ${{ github.event_name != 'repository_dispatch' && !cancelled() }}
     needs: [mise, pre-commit, rust, coverage, npm, error-enums]
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +79,7 @@ jobs:
 
   tag-release:
     name: Tag release
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'repository_dispatch' && github.ref == 'refs/heads/main'
     needs: [checks]
     concurrency:
       group: release
@@ -79,13 +89,14 @@ jobs:
 
   post-release:
     name: Post-release PR
-    if: github.ref == 'refs/heads/main' && needs.tag-release.outputs.tagged == 'true'
+    if: github.event_name != 'repository_dispatch' && github.ref == 'refs/heads/main' && needs.tag-release.outputs.tagged == 'true'
     needs: [tag-release]
     uses: ./.github/workflows/reflow-post-release.yml
     secrets: inherit
 
   release-config:
     name: Release config
+    if: github.event_name != 'repository_dispatch'
     needs: [version]
     runs-on: ubuntu-latest
     outputs:
@@ -127,6 +138,7 @@ jobs:
 
   release-npm:
     name: Release npm
+    if: github.event_name != 'repository_dispatch'
     needs: [release-config, version, build, checks]
     uses: ./.github/workflows/reflow-release-npm.yml
     permissions:
@@ -140,6 +152,7 @@ jobs:
 
   cargo-publish:
     name: Publish crates
+    if: github.event_name != 'repository_dispatch'
     needs: [release-config, checks]
     runs-on: ubuntu-latest
     permissions:
@@ -169,17 +182,20 @@ jobs:
 
   publish-release:
     name: GitHub Release
+    if: github.event_name != 'repository_dispatch'
     needs: [release-config, version, build, release-npm, cargo-publish]
     uses: ./.github/workflows/reflow-publish-release.yml
     permissions:
+      actions: read
       contents: write
     with:
       publish: ${{ needs.release-config.outputs.publish == 'true' }}
       version: ${{ needs.version.outputs.version }}
+      release-tag: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
 
   all:
     name: all
-    if: ${{ !cancelled() }}
+    if: ${{ github.event_name != 'repository_dispatch' && !cancelled() }}
     needs: [checks, tag-release, post-release, release-npm, cargo-publish, publish-release]
     runs-on: ubuntu-latest
     steps:
@@ -187,3 +203,15 @@ jobs:
         with:
           allowed-skips: tag-release, post-release
           jobs: ${{ toJSON(needs) }}
+
+  recover-release:
+    name: Recover release
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'recover-release'
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/reflow-recover-release.yml
+    with:
+      release-tag: ${{ github.event.client_payload.release_tag }}
+      source-run-id: ${{ github.event.client_payload.source_run_id }}

--- a/.github/workflows/reflow-publish-release.yml
+++ b/.github/workflows/reflow-publish-release.yml
@@ -11,30 +11,56 @@ on:
         description: "Release version (e.g., 0.5.0)"
         type: string
         required: true
+      release-tag:
+        description: "Existing tag to use for the GitHub Release (e.g., v0.5.0)"
+        type: string
+        required: true
+      artifact-run-id:
+        description: "Run containing binary artifacts; empty uses the current run"
+        type: string
+        default: ""
 
 jobs:
   github-release:
     name: GitHub Release
     runs-on: ubuntu-latest
+    concurrency:
+      group: github-release-${{ inputs.release-tag }}
+      cancel-in-progress: false
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.publish && inputs.release-tag || github.sha }}
 
       - name: Generate library matrix
         id: library
         uses: ./.github/actions/library
 
       - name: Download binary artifacts
+        if: inputs.artifact-run-id == ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: binary-*
           path: binaries
 
+      - name: Download recovery binary artifacts
+        if: inputs.artifact-run-id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: binary-*
+          path: binaries
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.artifact-run-id }}
+
       - name: Package release archives
         shell: bash
         env:
           PLATFORMS: ${{ steps.library.outputs.matrix }}
+          SOURCE_REF: ${{ inputs.publish && inputs.release-tag || github.sha }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -56,11 +82,34 @@ jobs:
             chmod +x "$staging_dir/${binary_name}"
             cp LICENSE-MIT LICENSE-APACHE "$staging_dir/"
 
+            source_date_epoch=$(git log -1 --format=%ct "$SOURCE_REF")
+            touch -d "@${source_date_epoch}" \
+              "$staging_dir" \
+              "$staging_dir/${binary_name}" \
+              "$staging_dir/LICENSE-MIT" \
+              "$staging_dir/LICENSE-APACHE"
+
             # Create archive
             if [[ "$archive_format" == "tar.gz" ]]; then
-              tar -czf "dist/release/${archive_name}.tar.gz" -C dist/staging "$archive_name"
+              tar \
+                --sort=name \
+                --mtime="@${source_date_epoch}" \
+                --owner=0 \
+                --group=0 \
+                --numeric-owner \
+                -cf - \
+                -C dist/staging \
+                "$archive_name" \
+                | gzip -n > "dist/release/${archive_name}.tar.gz"
             elif [[ "$archive_format" == "zip" ]]; then
-              (cd dist/staging && zip -r "../release/${archive_name}.zip" "$archive_name")
+              (
+                cd dist/staging
+                zip -X "../release/${archive_name}.zip" \
+                  "$archive_name/" \
+                  "$archive_name/${binary_name}" \
+                  "$archive_name/LICENSE-MIT" \
+                  "$archive_name/LICENSE-APACHE"
+              )
             else
               echo "ERROR: Unknown archive format '${archive_format}' for ${rust_target}" >&2
               exit 1
@@ -93,7 +142,7 @@ jobs:
         if: inputs.publish
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.release-tag }}
           VERSION: ${{ inputs.version }}
         shell: bash
         run: |
@@ -104,8 +153,51 @@ jobs:
           done
           assets+=("dist/SHA256SUMS")
 
-          echo "Creating release ${TAG} with ${#assets[@]} assets..."
-          gh release create "$TAG" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            "${assets[@]}"
+          if ! release=$(gh release view "$TAG" --json isDraft,assets 2>/dev/null); then
+            echo "Creating release ${TAG} with ${#assets[@]} assets..."
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "v${VERSION}" \
+              --generate-notes \
+              "${assets[@]}"
+            exit 0
+          fi
+
+          echo "Release ${TAG} already exists; verifying assets..."
+          existing_dir="$RUNNER_TEMP/existing-release"
+          mkdir -p "$existing_dir"
+
+          for asset in "${assets[@]}"; do
+            name=$(basename "$asset")
+            existing="$existing_dir/$name"
+            asset_count=$(jq --arg name "$name" \
+              '[.assets[] | select(.name == $name)] | length' <<< "$release")
+            if [[ "$asset_count" == "0" ]]; then
+              echo "Uploading missing asset $name..."
+              gh release upload "$TAG" "$asset"
+              continue
+            elif [[ "$asset_count" != "1" ]]; then
+              echo "ERROR: Release has $asset_count assets named $name" >&2
+              exit 1
+            fi
+
+            gh release download "$TAG" --pattern "$name" --dir "$existing_dir"
+
+            expected=$(sha256sum "$asset" | cut -d' ' -f1)
+            actual=$(sha256sum "$existing" | cut -d' ' -f1)
+            if [[ "$actual" != "$expected" ]]; then
+              echo "ERROR: Existing release asset $name has different contents" >&2
+              exit 1
+            fi
+            echo "Asset $name already exists with matching SHA-256."
+          done
+
+          if [[ $(jq -r '.isDraft' <<< "$release") == "true" ]]; then
+            echo "Publishing recovered draft release $TAG..."
+            gh release edit "$TAG" --draft=false
+          fi
+
+          if [[ $(gh release view "$TAG" --json isDraft --jq '.isDraft') != "false" ]]; then
+            echo "ERROR: Release $TAG is still a draft" >&2
+            exit 1
+          fi

--- a/.github/workflows/reflow-recover-release.yml
+++ b/.github/workflows/reflow-recover-release.yml
@@ -1,0 +1,256 @@
+name: Recover release
+
+on:
+  workflow_call:
+    inputs:
+      release-tag:
+        description: "Existing release tag to recover (e.g., v0.5.0)"
+        type: string
+        required: true
+      source-run-id:
+        description: "Failed tag run containing the original release artifacts"
+        type: string
+        required: true
+
+jobs:
+  library:
+    name: Generate library
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reflow-library.yml
+
+  validate-source:
+    name: Validate source
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.release-tag }}
+          fetch-depth: 0
+
+      - name: Validate tag and source run
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+          SOURCE_RUN_ID: ${{ inputs.source-run-id }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "ERROR: Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          version=$(yq -r '.workspace.package.version' Cargo.toml)
+          if [[ "v${version}" != "$RELEASE_TAG" ]]; then
+            echo "ERROR: Cargo version $version does not match $RELEASE_TAG" >&2
+            exit 1
+          fi
+          node scripts/sync-versions.js --check
+
+          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+          run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
+          source_event=$(jq -r '.event' <<< "$run")
+          source_branch=$(jq -r '.head_branch' <<< "$run")
+          source_sha=$(jq -r '.head_sha' <<< "$run")
+          source_workflow=$(jq -r '.path' <<< "$run")
+
+          if [[ "$source_event" != "push" \
+            || "$source_branch" != "$RELEASE_TAG" \
+            || "$source_sha" != "$tag_sha" \
+            || "$source_workflow" != ".github/workflows/ci.yml" ]]; then
+            echo "ERROR: Source run does not match $RELEASE_TAG and ci.yml" >&2
+            jq '{event, head_branch, head_sha, path, html_url}' <<< "$run" >&2
+            exit 1
+          fi
+
+          artifacts=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")
+          expected=(
+            npm-tarballs
+            binary-linux-x64
+            binary-linux-arm64
+            binary-darwin-x64
+            binary-darwin-arm64
+            binary-win32-x64
+          )
+          for name in "${expected[@]}"; do
+            count=$(jq --arg name "$name" \
+              '[.artifacts[] | select(.name == $name and .expired == false)] | length' \
+              <<< "$artifacts")
+            if [[ "$count" != "1" ]]; then
+              echo "ERROR: Expected one unexpired $name artifact, found $count" >&2
+              exit 1
+            fi
+          done
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Validated $RELEASE_TAG at $tag_sha using source run $SOURCE_RUN_ID."
+
+  recover-npm:
+    name: Recover npm packages
+    needs: [validate-source]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: npm-publish-${{ needs.validate-source.outputs.version }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout recovery code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download npm tarballs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm-tarballs
+          path: tarballs
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source-run-id }}
+
+      - name: Validate and publish npm tarballs
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate-source.outputs.version }}
+        run: |
+          shopt -s failglob
+          tarballs=(
+            ./tarballs/onshape-mcp-linux-x64-*.tgz
+            ./tarballs/onshape-mcp-linux-arm64-*.tgz
+            ./tarballs/onshape-mcp-darwin-x64-*.tgz
+            ./tarballs/onshape-mcp-darwin-arm64-*.tgz
+            ./tarballs/onshape-mcp-win32-x64-*.tgz
+            ./tarballs/onshape-mcp-opencode-auth-*.tgz
+            ./tarballs/onshape-mcp-[0-9]*.tgz
+          )
+          if [[ ${#tarballs[@]} -ne 7 ]]; then
+            echo "ERROR: Expected exactly 7 npm tarballs, found ${#tarballs[@]}" >&2
+            exit 1
+          fi
+
+          expected_names=$(
+            printf '%s\n' \
+              @onshape-mcp/linux-x64 \
+              @onshape-mcp/linux-arm64 \
+              @onshape-mcp/darwin-x64 \
+              @onshape-mcp/darwin-arm64 \
+              @onshape-mcp/win32-x64 \
+              @onshape-mcp/opencode-auth \
+              onshape-mcp \
+              | sort
+          )
+          actual_names=$(
+            for tarball in "${tarballs[@]}"; do
+              metadata=$(npm pack --dry-run --json "$tarball")
+              name=$(jq -r '.[0].name' <<< "$metadata")
+              package_version=$(jq -r '.[0].version' <<< "$metadata")
+              if [[ "$package_version" != "$VERSION" ]]; then
+                echo "ERROR: $tarball has version $package_version, expected $VERSION" >&2
+                exit 1
+              fi
+              printf '%s\n' "$name"
+            done | sort
+          )
+          if [[ "$actual_names" != "$expected_names" ]]; then
+            echo "ERROR: npm tarballs do not contain the expected package set" >&2
+            printf 'Expected:\n%s\nActual:\n%s\n' "$expected_names" "$actual_names" >&2
+            exit 1
+          fi
+
+          for tarball in "${tarballs[@]}"; do
+            .github/scripts/npm-publish-tarball.sh "$tarball" latest
+          done
+
+  verify-published:
+    name: "Verify npm published (${{ matrix.platform.name }})"
+    needs: [library, validate-source, recover-npm]
+    runs-on: ${{ matrix.platform.runner }}
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.library.outputs.matrix).release }}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+
+      - name: Install from registry
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate-source.outputs.version }}
+          NPM_PLATFORM: ${{ matrix.platform.npm-platform }}
+        run: |
+          mkdir test-registry-install
+          cd test-registry-install
+          npm init -y
+
+          bin_name="onshape-mcp"
+          if [[ "$NPM_PLATFORM" == win32-* ]]; then
+            bin_name="onshape-mcp.exe"
+          fi
+          expected_bin="node_modules/@onshape-mcp/${NPM_PLATFORM}/bin/${bin_name}"
+
+          max_attempts=15
+          delay=30
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "Attempt ${attempt}/${max_attempts}: installing onshape-mcp@${VERSION}..."
+            install_ok=false
+            if npm install "onshape-mcp@${VERSION}"; then
+              install_ok=true
+            fi
+            if [[ "$install_ok" == "true" ]] && [[ -f "$expected_bin" ]]; then
+              echo "Install succeeded and platform binary exists: ${expected_bin}"
+              break
+            fi
+            if [[ "$attempt" -eq "$max_attempts" ]]; then
+              echo "ERROR: Install failed after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+            rm -rf node_modules package-lock.json
+            sleep "$delay"
+          done
+
+      - name: Verify binary version
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate-source.outputs.version }}
+        run: |
+          cd test-registry-install
+          output=$(npx --yes onshape-mcp --version 2>&1)
+          echo "Binary output: $output"
+          if ! grep -qF "$VERSION" <<< "$output"; then
+            echo "ERROR: Expected version $VERSION in output: $output" >&2
+            exit 1
+          fi
+
+  recover-github-release:
+    name: Recover GitHub Release
+    needs: [validate-source, verify-published]
+    uses: ./.github/workflows/reflow-publish-release.yml
+    permissions:
+      actions: read
+      contents: write
+    with:
+      publish: true
+      version: ${{ needs.validate-source.outputs.version }}
+      release-tag: ${{ inputs.release-tag }}
+      artifact-run-id: ${{ inputs.source-run-id }}

--- a/.github/workflows/reflow-release-npm.yml
+++ b/.github/workflows/reflow-release-npm.yml
@@ -209,6 +209,9 @@ jobs:
     if: inputs.publish
     needs: [library, package, test-tarballs]
     runs-on: ubuntu-latest
+    concurrency:
+      group: npm-publish-${{ inputs.version }}
+      cancel-in-progress: false
     outputs:
       published: ${{ steps.check-auth.outputs.can-publish }}
     steps:
@@ -249,6 +252,10 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Checkout publish helper
+        if: steps.check-auth.outputs.can-publish == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - name: Download tarballs
         if: steps.check-auth.outputs.can-publish == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -273,7 +280,7 @@ jobs:
               exit 1
             fi
             echo "Publishing ${tarballs[0]}..."
-            npm publish "${tarballs[0]}" --tag "$DIST_TAG" --access public
+            .github/scripts/npm-publish-tarball.sh "${tarballs[0]}" "$DIST_TAG"
           done < <(echo "$PLATFORMS" | jq -c '.[]')
 
       - name: Publish plugin package
@@ -290,7 +297,7 @@ jobs:
             exit 1
           fi
           echo "Publishing ${tarballs[0]}..."
-          npm publish "${tarballs[0]}" --tag "$DIST_TAG" --access public
+          .github/scripts/npm-publish-tarball.sh "${tarballs[0]}" "$DIST_TAG"
 
       - name: Publish main package
         if: steps.check-auth.outputs.can-publish == 'true'
@@ -306,7 +313,7 @@ jobs:
             exit 1
           fi
           echo "Publishing ${tarballs[0]}..."
-          npm publish "${tarballs[0]}" --tag "$DIST_TAG" --access public
+          .github/scripts/npm-publish-tarball.sh "${tarballs[0]}" "$DIST_TAG"
 
   test-published:
     name: "Test npm published (${{ matrix.platform.name }})"

--- a/docs/src/project/release.md
+++ b/docs/src/project/release.md
@@ -14,7 +14,7 @@ Users can install the server via:
 
 CI and release share a single unified pipeline in `ci.yml`. A `release-config` job inspects the trigger (tag push vs PR/branch push) and centralizes all mode-dependent decisions. Downstream jobs consume named outputs and have no conditional logic of their own.
 
-The pipeline is composed of four reusable workflows plus one inline job:
+The pipeline is composed of five reusable workflows plus one inline job:
 
 | Component | Purpose |
 | --------- | ------- |
@@ -22,6 +22,7 @@ The pipeline is composed of four reusable workflows plus one inline job:
 | `reflow-release-build.yml` | Build release binaries on 5 platforms |
 | `reflow-release-npm.yml` | Package, publish, and test npm packages (parameterized by version and dist-tag) |
 | `reflow-publish-release.yml` | Package archives, generate SHA256SUMS, create GitHub Release |
+| `reflow-recover-release.yml` | Recover a partial tagged release from its original workflow artifacts |
 | `cargo-publish` job | Publish workspace crates to crates.io (or `cargo package` validation) |
 
 ### Trigger Behavior
@@ -324,6 +325,28 @@ Packages release archives and creates a GitHub Release. Parameterized by `publis
 | Platform archives (5) | Binary + `LICENSE-MIT` + `LICENSE-APACHE` per platform |
 | `SHA256SUMS` | SHA-256 checksums for all archives |
 
+### Partial Release Recovery
+
+`ci.yml` supports a guarded `recover-release` repository dispatch for a tagged release that published only some artifacts.
+Recovery requires the release tag and the failed tag run ID.
+Repository dispatches always use the workflow from the repository's default branch, preventing recovery code from being selected from an unreviewed branch.
+It verifies that the source run used `ci.yml`, was triggered by that tag, and has the same commit as the tag before downloading any artifacts.
+
+The recovery workflow uses the original `npm-tarballs` and `binary-*` artifacts rather than rebuilding from the current branch.
+For npm packages, an existing version is skipped only when its registry integrity matches the original tarball exactly.
+Missing packages are published in platform, plugin, then main-package order and tested by exact version on all platforms.
+The GitHub Release is created or completed from the original binary artifacts.
+
+Recovery is dispatched through `ci.yml` so npm trusted publishing continues to recognize the configured workflow identity.
+Normal CI and release jobs are skipped during a recovery dispatch.
+
+```bash
+gh api repos/altendky/onshape-mcp/dispatches \
+  -f event_type=recover-release \
+  -f 'client_payload[release_tag]=v0.5.0' \
+  -f 'client_payload[source_run_id]=29884259705'
+```
+
 ## Artifacts
 
 Artifacts are shared across workflow runs via GitHub Actions upload/download.
@@ -393,11 +416,13 @@ It is generated in `reflow-publish-release.yml` on every CI run (validating the 
 | `.github/workflows/reflow-release-build.yml` | Reusable: build release binaries on 5 platforms |
 | `.github/workflows/reflow-release-npm.yml` | Reusable: package, publish, and test npm packages |
 | `.github/workflows/reflow-publish-release.yml` | Reusable: package archives, generate SHA256SUMS, create GitHub Release |
+| `.github/workflows/reflow-recover-release.yml` | Reusable: validate and recover a partial tagged release |
 | `.github/workflows/reflow-tag-release.yml` | Reusable: auto-tag on release merge |
 | `.github/workflows/reflow-post-release.yml` | Reusable: create signed post-release version bump PR |
 | `.github/workflows/cleanup-npm-staging.yml` | Scheduled: unpublish staging packages older than 2.2 days (52.8 hours) |
 | `.github/scripts/compute-staging-version.sh` | Computes staging version with sanitized ref, commit SHA, run ID |
 | `.github/scripts/cargo-publish-workspace.sh` | Publishes all workspace crates to crates.io in dependency order |
+| `.github/scripts/npm-publish-tarball.sh` | Publishes an npm tarball or verifies an identical existing version |
 
 ## Modified Files
 
@@ -472,4 +497,4 @@ Items requiring further discussion before or during implementation.
 
 ### Workflow Inputs
 
-- [x] `workflow_dispatch` inputs: ~~determine whether to accept parameters~~ Resolved: removed. Release is triggered only by tag push. The unified `ci.yml` pipeline exercises the full release flow on every PR — including `cargo package --workspace`, archive packaging, and SHA256SUMS generation — providing comprehensive coverage without a manual dispatch trigger. See [#88](https://github.com/altendky/onshape-mcp/issues/88)
+- [x] Manual recovery inputs: Normal releases are triggered only by tag push. A guarded `repository_dispatch` accepts an existing release tag and source run ID solely to recover a partial release from its original artifacts. The unified `ci.yml` pipeline exercises the full release flow on every PR, while recovery mode skips normal CI jobs. See [#88](https://github.com/altendky/onshape-mcp/issues/88)


### PR DESCRIPTION
## Summary

- make npm publication retry-safe by verifying exact registry integrity and dist-tags before skipping existing versions
- add a guarded `recover-release` repository dispatch through `ci.yml` so npm OIDC continues to use the configured trusted-publisher identity
- recover npm and GitHub Release assets from an original failed tag run instead of rebuilding them from current sources
- make release archives deterministic and safely complete existing draft or partial GitHub Releases

## Recovery Safety

- repository dispatch always executes reviewed workflow code from the default branch
- source workflow, tag, commit, and unexpired artifact set must all match
- existing npm versions must match the original tarball integrity exactly
- package and GitHub Release publication is serialized by version/tag
- recovered npm packages are installed and smoke-tested on all supported platforms

## Verification

- `pre-commit run --all-files`
- validated all seven npm tarballs from source run `29884259705` as version `0.5.0`
- verified the original Linux x64 and ARM64 tarballs match the already-published npm integrity and `latest` dist-tag
- independent post-change review found no blocking correctness or recovery-path security issues
