### PR TITLE
Remove redundant OAuth auth overrides

### DIFF
--- a/crates/onshape-mcp-io/src/oauth_server.rs
+++ b/crates/onshape-mcp-io/src/oauth_server.rs
@@ -312,14 +312,11 @@ impl OAuthServerState {
 
         eprintln!("[oauth] refreshing Onshape tokens for user {user_id}");
 
-        // Build OAuth client using server's Onshape app credentials.
-        // Use RequestBody auth (client_secret_post) — Onshape requires
-        // credentials in the POST body, not HTTP Basic auth.
+        // The shared client configures Onshape's required request-body authentication.
         let onshape_client = onshape_oauth_client(
             &self.onshape_client_id,
             self.onshape_client_secret.expose_secret(),
-        )
-        .set_auth_type(oauth2::AuthType::RequestBody);
+        );
 
         let http_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
@@ -801,13 +798,11 @@ async fn exchange_onshape_code(
 > {
     eprintln!("[oauth] callback: exchanging Onshape authorization code for tokens");
 
-    // Use RequestBody (client_secret_post) auth — Onshape requires credentials
-    // in the POST body rather than an HTTP Basic Authorization header.
+    // The shared client configures Onshape's required request-body authentication.
     let onshape_client = onshape_oauth_client(
         &state.onshape_client_id,
         state.onshape_client_secret.expose_secret(),
-    )
-    .set_auth_type(oauth2::AuthType::RequestBody);
+    );
 
     let callback_url = state.url_with_path(&["oauth", "callback"]);
     let redirect_url = oauth2::RedirectUrl::new(callback_url).map_err(|e| {


### PR DESCRIPTION
## Summary

- Remove the redundant per-call request-body authentication overrides from the Onshape token refresh and authorization-code exchange paths.
- Keep concise comments identifying the shared Onshape OAuth client as the source of the required authentication mode.
- Confirm no equivalent per-call override remains elsewhere.

## Stack

This cleanup depends on #678, which centralizes Onshape's required request-body client authentication. It was authored as a stacked PR, so its visible diff included #678 until that PR merged. #678 merged while this PR was being prepared; GitHub now shows only this cleanup against `main`.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
