### PR TITLE
Restore CI while Rust 1.98.1 Docker images are pending

### DIFF
--- a/.github/actions/resolve-rust-versions/resolve.sh
+++ b/.github/actions/resolve-rust-versions/resolve.sh
@@ -123,7 +123,14 @@ else
 		# Anchor to end-of-day since STABLE_RELEASE_DATE is date-only (no time).
 		# This ensures the grace period is at least GRACE_PERIOD_HOURS from the
 		# actual release moment, at the cost of up to ~24h extra tolerance.
-		if is_within_grace_period "${STABLE_RELEASE_DATE}T23:59:59Z" "$GRACE_PERIOD_HOURS"; then
+		# Temporary exception while publication of the official Rust 1.98.1 images is
+		# blocked upstream: https://github.com/docker-library/official-images/pull/22200
+		# Remove this branch after rust:1.98.1-alpine is published.
+		if [ "$RUSTUP_STABLE" = "1.98.1" ] && [ "$PREV_VERSION" = "1.98.0" ]; then
+			echo "::warning::Using previous version ${PREV_VERSION} while the official Rust ${RUSTUP_STABLE} images are pending upstream"
+			RESOLVED_STABLE="$PREV_VERSION"
+			STABLE_DOCKER_AVAILABLE="true"
+		elif is_within_grace_period "${STABLE_RELEASE_DATE}T23:59:59Z" "$GRACE_PERIOD_HOURS"; then
 			echo "::warning::Using previous version ${PREV_VERSION} (stable ${RUSTUP_STABLE} released ${STABLE_RELEASE_DATE}, within ${GRACE_PERIOD_HOURS}h grace period)"
 			RESOLVED_STABLE="$PREV_VERSION"
 			STABLE_DOCKER_AVAILABLE="true"

--- a/crates/onshape-mcp-io/src/oauth_server.rs
+++ b/crates/onshape-mcp-io/src/oauth_server.rs
@@ -1351,7 +1351,7 @@ pub(crate) async fn auth_middleware(
     State(state): State<Arc<OAuthServerState>>,
     mut request: http::Request<axum::body::Body>,
     next: middleware::Next,
-) -> Result<axum::response::Response, axum::response::Response> {
+) -> axum::response::Response {
     let method = request.method().clone();
     let uri = request.uri().clone();
 
@@ -1363,10 +1363,7 @@ pub(crate) async fn auth_middleware(
 
     let Some(auth_value) = auth_header else {
         eprintln!("[oauth] auth: {method} {uri} — missing Authorization header");
-        return Err(unauthorized_response(
-            "invalid_request",
-            "Missing Authorization header",
-        ));
+        return unauthorized_response("invalid_request", "Missing Authorization header");
     };
 
     // Parse scheme case-insensitively per RFC 9110 Section 11.1.
@@ -1374,18 +1371,12 @@ pub(crate) async fn auth_middleware(
         &auth_value[7..]
     } else {
         eprintln!("[oauth] auth: {method} {uri} — invalid Authorization header format");
-        return Err(unauthorized_response(
-            "invalid_request",
-            "Invalid Authorization header format",
-        ));
+        return unauthorized_response("invalid_request", "Invalid Authorization header format");
     };
 
     let Some(user_ctx) = state.validate_token(token).await else {
         eprintln!("[oauth] auth: {method} {uri} — invalid or expired token");
-        return Err(unauthorized_response(
-            "invalid_token",
-            "Invalid or expired token",
-        ));
+        return unauthorized_response("invalid_token", "Invalid or expired token");
     };
 
     eprintln!(
@@ -1393,7 +1384,7 @@ pub(crate) async fn auth_middleware(
         user_ctx.user_id
     );
     request.extensions_mut().insert(user_ctx);
-    Ok(next.run(request).await)
+    next.run(request).await
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- temporarily permit the available Rust 1.98.0 Alpine image while the official 1.98.1 images are pending
- preserve the existing Docker lag enforcement for every other Rust release
- fix the Rust 1.98 `result_large_err` Clippy failure by returning Axum responses directly

Upstream image publication is tracked by:

https://github.com/docker-library/official-images/pull/22200

## Verification

- `bash -n .github/actions/resolve-rust-versions/resolve.sh`
- live resolver execution selected Rust 1.98.0 and completed successfully
- `cargo +1.98.0 fmt --all --check`
- `cargo +1.98.0 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.98.0 test -p onshape-mcp-io` (142 passed)
