### PR TITLE
Disable automatic Rust MSRV updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,6 +42,13 @@
       "groupName": "Rust toolchain"
     },
 
+    // MSRV is a deliberate compatibility policy, not a latest-Rust pin.
+    {
+      "matchDepNames": ["rust-lang/rust"],
+      "matchFileNames": ["Cargo.toml"],
+      "enabled": false
+    },
+
     // Override extractVersion for nextest (version_prefix workaround)
     {
       "matchDepNames": ["github:nextest-rs/nextest"],


### PR DESCRIPTION
## Summary

- Disable Renovate's automatic updates to the minimum supported Rust version (MSRV) declared in the root Cargo manifest.
- Scope the rule to that manifest so development toolchain and Docker image updates remain enabled.
- Document that MSRV changes are deliberate compatibility decisions.

This makes the policy behind closing #542 apply to future Rust releases as well. The development toolchain and Docker update is tracked separately in #484.

## Verification

- Renovate configuration validator passed.
- `pre-commit run --files renovate.json5` passed.
- `git diff --check` passed.
