### PR TITLE
Reduce CI runner usage and warm tool caches

### DIFF
--- a/.github/actions/library/action.yml
+++ b/.github/actions/library/action.yml
@@ -14,5 +14,5 @@ runs:
           echo "yq is required but not installed. Install it in the caller or add an install step here." >&2
           exit 1
         fi
-        MATRIX=$(yq -o=json -I=0 '.' "${{ github.action_path }}/library.yml")
+        MATRIX=$(yq -o=json -I=0 '.axes[] |= map(select(.enabled != false))' "${{ github.action_path }}/library.yml")
         echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/actions/library/library.yml
+++ b/.github/actions/library/library.yml
@@ -7,6 +7,8 @@ axes:
         arm: ubuntu-24.04-arm
         intel: ubuntu-latest
     - name: macOS
+      # Keep macOS coverage to the native release builds and their --version checks.
+      enabled: false
       matrix: macos
       emoji: 🍎
       runs-on:
@@ -35,6 +37,8 @@ axes:
       version: stable
       emoji: 🪨
     - name: beta
+      # Disable advisory beta jobs to reduce runner usage; set true to restore them.
+      enabled: false
       matrix: beta
       version: beta
       emoji: 🔮

--- a/.github/actions/resolve-rust-versions/action.yml
+++ b/.github/actions/resolve-rust-versions/action.yml
@@ -5,6 +5,10 @@ inputs:
   msrv:
     description: Minimum Supported Rust Version
     required: true
+  include-beta:
+    description: Resolve the beta channel when enabled in the CI matrix
+    required: false
+    default: "true"
   grace-period-hours:
     description: Grace period in hours for version lag between sources
     required: false
@@ -32,4 +36,5 @@ runs:
       shell: bash
       env:
         GRACE_PERIOD_HOURS: ${{ inputs.grace-period-hours }}
+        INCLUDE_BETA: ${{ inputs.include-beta }}
       run: ${{ github.action_path }}/resolve.sh

--- a/.github/actions/resolve-rust-versions/resolve.sh
+++ b/.github/actions/resolve-rust-versions/resolve.sh
@@ -73,10 +73,13 @@ RUSTUP_STABLE=$(echo "$STABLE_TOML" | yq -p toml '.pkg.rust.version' | grep -oP 
 STABLE_RELEASE_DATE=$(echo "$STABLE_TOML" | yq -p toml '.date')
 echo "Rustup stable: $RUSTUP_STABLE (released $STABLE_RELEASE_DATE)"
 
-# Get beta version from rustup
-echo "Querying rustup for beta version..."
-RUSTUP_BETA=$(get_rustup_version "beta")
-echo "Rustup beta: $RUSTUP_BETA"
+# Disabled beta jobs should not depend on the beta channel being available.
+RUSTUP_BETA=""
+if [ "${INCLUDE_BETA:-true}" = "true" ]; then
+	echo "Querying rustup for beta version..."
+	RUSTUP_BETA=$(get_rustup_version "beta")
+	echo "Rustup beta: $RUSTUP_BETA"
+fi
 
 # Check Docker Hub for stable version
 echo "Checking Docker Hub for rust:${RUSTUP_STABLE}-alpine..."

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Comma-separated list of components to install (e.g., "rustfmt, clippy")
     required: false
     default: ""
+  cache-key:
+    description: Additional key to distinguish caches for jobs with the same ID
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -18,3 +22,4 @@ runs:
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
+        cache-key: ${{ inputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,31 @@ jobs:
     name: Mise
     uses: ./.github/workflows/reflow-mise.yml
 
+  mise-warmup:
+    name: Mise warmup
+    uses: ./.github/workflows/reflow-mise-warmup.yml
+
   pre-commit:
     name: Pre-commit
+    needs: mise-warmup
     uses: ./.github/workflows/reflow-pre-commit.yml
 
   rust:
     name: Rust
+    needs: mise-warmup
     uses: ./.github/workflows/reflow-rust.yml
     secrets: inherit
 
   coverage:
     name: Coverage
+    needs: mise-warmup
     uses: ./.github/workflows/reflow-coverage.yml
     permissions:
       id-token: write
 
   npm:
     name: npm
+    needs: mise-warmup
     uses: ./.github/workflows/reflow-npm.yml
     permissions:
       id-token: write
@@ -49,6 +57,7 @@ jobs:
 
   error-enums:
     name: Error enums
+    needs: mise-warmup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -64,7 +73,7 @@ jobs:
   checks:
     name: checks
     if: ${{ !cancelled() }}
-    needs: [mise, pre-commit, rust, coverage, npm, error-enums]
+    needs: [mise, mise-warmup, pre-commit, rust, coverage, npm, error-enums]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1

--- a/.github/workflows/reflow-mise-warmup.yml
+++ b/.github/workflows/reflow-mise-warmup.yml
@@ -1,0 +1,27 @@
+name: Mise Warmup
+
+on:
+  workflow_call:
+
+jobs:
+  library:
+    name: Generate library
+    uses: ./.github/workflows/reflow-library.yml
+
+  warmup:
+    name: Warm tools (${{ matrix.os.name }} ${{ matrix.arch.name }})
+    needs: library
+    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.library.outputs.matrix).axes.os }}
+        arch: ${{ fromJSON(needs.library.outputs.matrix).axes.arch }}
+        exclude: ${{ fromJSON(needs.library.outputs.matrix).exclude.windows-arm }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Populate each platform's cache before the consumers fan out on a cold key.
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
+        env:
+          RUSTUP_TOOLCHAIN: stable

--- a/.github/workflows/reflow-pre-commit.yml
+++ b/.github/workflows/reflow-pre-commit.yml
@@ -25,6 +25,14 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: stable
 
+      - name: Setup Rust and cache Clippy dependencies
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          # Coverage also has a job named check; keep Clippy's artifacts separate.
+          cache-key: pre-commit
+
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/reflow-release-npm.yml
+++ b/.github/workflows/reflow-release-npm.yml
@@ -143,6 +143,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ fromJSON(needs.library.outputs.matrix).release }}
+        # macOS is build-only; its binaries are still included in every package.
+        exclude:
+          - platform: { name: darwin-x64 }
+          - platform: { name: darwin-arm64 }
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -317,6 +321,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ fromJSON(needs.library.outputs.matrix).release }}
+        # Match the build-only macOS policy used for tarball validation.
+        exclude:
+          - platform: { name: darwin-x64 }
+          - platform: { name: darwin-arm64 }
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -10,6 +10,7 @@ jobs:
 
   resolve-versions:
     name: Resolve Rust versions
+    needs: library
     runs-on: ubuntu-latest
     outputs:
       msrv: ${{ steps.resolve.outputs.msrv }}
@@ -23,6 +24,7 @@ jobs:
         uses: ./.github/actions/resolve-rust-versions
         with:
           msrv: "1.89"
+          include-beta: ${{ contains(fromJSON(needs.library.outputs.matrix).axes.rust.*.matrix, 'beta') }}
 
   # Lint job runs separately (doesn't need build/test split)
   lint:

--- a/docs/src/project/ci.md
+++ b/docs/src/project/ci.md
@@ -118,10 +118,11 @@ Store credentials in repository secrets:
 | `.mergify.yml` | Mergify merge queue and autoqueue configuration |
 | `.github/workflows/ci.yml` | Entry point for CI and releases, calls reusable workflows, `all` job aggregation |
 | `.github/workflows/reflow-library.yml` | Reusable workflow that outputs matrix configuration |
-| `.github/workflows/reflow-pre-commit.yml` | Reusable workflow for pre-commit checks (5 platform jobs) |
+| `.github/workflows/reflow-mise-warmup.yml` | Warms tool caches on the 3 check platforms before fanout |
+| `.github/workflows/reflow-pre-commit.yml` | Reusable workflow for pre-commit checks (3 platform jobs) |
 | `.github/workflows/reflow-rust.yml` | Reusable workflow for Rust lint, build, and test jobs |
-| `.github/workflows/reflow-coverage.yml` | Reusable workflow for Rust coverage generation (5 platform jobs) |
-| `.github/workflows/reflow-npm.yml` | Reusable workflow for npm checks and coverage (1 + 5 platform jobs) |
+| `.github/workflows/reflow-coverage.yml` | Reusable workflow for Rust coverage generation (3 platform jobs) |
+| `.github/workflows/reflow-npm.yml` | Reusable workflow for npm checks and coverage (1 + 3 platform jobs) |
 | `.github/workflows/reflow-release-version.yml` | Reusable workflow for version extraction and tag verification |
 | `.github/workflows/reflow-release-build.yml` | Reusable workflow for release binary builds (5 platforms) |
 | `.github/workflows/reflow-release-npm.yml` | Reusable workflow for npm package, publish, and test |
@@ -144,6 +145,25 @@ The concurrency group is only set on `ci.yml`. Reusable workflows (`reflow-*.yml
 
 The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Each reusable workflow appears as a collapsible group containing its matrix jobs.
 
+### Tool Cache Warmup
+
+`reflow-mise-warmup.yml` installs tools once on Linux Intel, Linux ARM, and Windows
+Intel before pre-commit, Rust, coverage, npm, and error-enum checks start. A cold
+tool-cache key is populated before the consumer jobs fan out, avoiding concurrent
+rebuilds of the same cache. Warmup and consumers use the same mise action and
+installation arguments so their cache keys match.
+
+Warmup runs on PRs, `main`, and tags through `ci.yml`. Caches populated on `main`
+are available to later PRs. The dry-run lockfile check remains independent with
+caching disabled, so it cannot populate an incomplete tools cache. The release
+builds use Rust setup directly and do not need mise warmup.
+
+The pre-commit jobs also use the shared Rust setup action, which caches Cargo
+dependencies and build artifacts for Clippy and installs rustfmt and Clippy on
+stable Rust. A dedicated cache key separates Clippy artifacts from coverage jobs.
+
+### Job Layout
+
 ```text
 ┌──────────────────────────────────────────────────────────────────┐
 │           ci.yml (entry point for CI and releases)                │
@@ -151,6 +171,10 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 │  triggers: push (main, v* tags), pull_request                     │
 │                                                                   │
 │  jobs:                                                            │
+│    mise-warmup:                                                   │
+│      uses: ./.github/workflows/reflow-mise-warmup.yml              │
+│      (pre-commit, rust, coverage, npm, error-enums wait for it)     │
+│                                                                   │
 │    pre-commit:                                                    │
 │      uses: ./.github/workflows/reflow-pre-commit.yml             │
 │                                                                   │
@@ -209,7 +233,7 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 ├─────────────────────────────────────────────────────────────┤
 │  jobs:                                                       │
 │    library: uses reflow-library.yml                         │
-│    check: 5 platform jobs (pre-commit/action)               │
+│    check: 3 platform jobs (pre-commit)                      │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -219,10 +243,10 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 │    library: uses reflow-library.yml                         │
 │    resolve-versions: resolves rustup/Docker Hub versions    │
 │    lint: 1 job (fmt, clippy, deny on stable)                │
-│    build: 15 jobs (3 rust × 5 platforms)                    │
+│    build: 6 jobs (2 rust × 3 platforms)                     │
 │      - Builds and archives tests with cargo-nextest         │
 │      - Linux builds target musl for static linking          │
-│    test: 21 jobs (3 rust × 7 platform/libc combinations)    │
+│    test: 10 jobs (2 rust × 5 platform/libc combinations)    │
 │      - Runs archived tests                                  │
 │      - Linux tests on both glibc and musl                   │
 └─────────────────────────────────────────────────────────────┘
@@ -232,7 +256,7 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 ├─────────────────────────────────────────────────────────────┤
 │  jobs:                                                       │
 │    library: uses reflow-library.yml                         │
-│    check: 5 platform jobs (cargo-llvm-cov, stable only)     │
+│    check: 3 platform jobs (cargo-llvm-cov, stable only)     │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -240,7 +264,7 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 ├─────────────────────────────────────────────────────────────┤
 │  jobs:                                                       │
 │    library: uses reflow-library.yml                         │
-│    coverage: 5 platform jobs (c8 coverage)                  │
+│    coverage: 3 platform jobs (c8 coverage)                  │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -253,7 +277,7 @@ The CI uses reusable workflows for visual grouping in the GitHub Actions UI. Eac
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Note:** Each reusable workflow calls `reflow-library.yml` internally to get the matrix configuration. This results in the library job running 6 times per CI run (once per reusable workflow that needs platform matrices), but the overhead is minimal.
+**Note:** Each reusable workflow calls `reflow-library.yml` internally to get the matrix configuration. This results in the library job running 7 times per CI run (once per reusable workflow that needs platform matrices), but the overhead is minimal.
 
 ## Library Action
 
@@ -273,6 +297,7 @@ axes:
         arm: ubuntu-24.04-arm
         intel: ubuntu-latest
     - name: macOS
+      enabled: false # Build-only coverage comes from the separate release matrix.
       # ...
     - name: Windows
       # ...
@@ -293,6 +318,7 @@ axes:
       version: stable
       emoji: 🪨
     - name: beta
+      enabled: false # Retained for easy re-enabling of advisory beta checks.
       matrix: beta
       version: beta
       emoji: 🔮
@@ -330,17 +356,24 @@ exclude:
 ```
 
 The action parses this YAML and outputs it as JSON for use in workflow matrices.
+Entries with `enabled: false` are filtered from each axis; omitted flags mean
+enabled. The separate `release` list includes all five distribution platforms.
+Beta version resolution is skipped while beta is disabled in the generated matrix.
 
 **Libc axis:** Used by the test job to run Linux tests on both glibc (Ubuntu) and musl (Alpine)
 environments, verifying that statically-linked musl binaries work correctly on glibc systems.
 
 ## Platform Matrix
 
-| OS | Architecture |
-| ---- | -------------- |
-| Linux (ubuntu) | ARM, Intel |
-| macOS | ARM, Intel |
-| Windows | Intel |
+| OS | Architecture | CI coverage |
+| ---- | -------------- | ----------- |
+| Linux (ubuntu) | ARM, Intel | Full checks, tests, and release builds |
+| macOS | ARM, Intel | Release builds and their `--version` smoke checks only |
+| Windows | Intel | Full checks, tests, and release builds |
+
+Both macOS binaries are packaged and published, but macOS does not run the Rust
+test suite, pre-commit, coverage, or npm installation tests. npm tarball and
+published-package installation tests run on the three Linux/Windows platforms.
 
 **Note:** Windows ARM is excluded due to insufficient ecosystem support.
 
@@ -350,35 +383,41 @@ environments, verifying that statically-linked musl binaries work correctly on g
 | ----------- | ---------- | ------- |
 | MSRV (1.89) | Yes | From `rust-toolchain.toml` |
 | Latest stable | Yes | Primary development target |
-| Beta | No | Allowed to fail |
+| Beta | Disabled | Set `enabled: true` in the library to restore advisory checks |
 
 ### Job Count
 
 | Workflow | Jobs |
 | -------- | ---- |
-| Pre-commit | 6 (1 library + 5 check) |
-| Rust | 39 (1 library + 1 resolve-versions + 1 lint + 15 build + 21 test) |
-| Coverage | 6 (1 library + 5 check) |
-| npm | 6 (1 library + 5 coverage) |
+| Mise lockfile | 1 |
+| Mise warmup | 4 (1 library + 3 warmup) |
+| Pre-commit | 4 (1 library + 3 check) |
+| Rust | 19 (1 library + 1 resolve-versions + 1 lint + 6 build + 10 test) |
+| Coverage | 4 (1 library + 3 check) |
+| npm | 4 (1 library + 3 coverage) |
+| Error enums | 1 |
 | Version | 1 |
 | Build | 6 (1 library + 5 build) |
 | Checks | 1 (alls-green gate) |
 | Release config | 1 |
-| Release npm | 13 (1 library + 1 package + 5 test-tarballs + 1 publish + 5 test-published) |
+| Release npm | 9 (1 library + 1 package + 3 test-tarballs + 1 publish + 3 test-published) |
 | Cargo publish | 1 |
 | GitHub Release | 1 |
 | All | 1 |
-| **Total** | **82 jobs** |
+| **Total (tag run)** | **58 jobs** |
+
+Counts exclude skipped jobs. An ordinary PR executes **54 jobs** because npm
+publication and registry tests are skipped; a non-release `main` push executes
+**55**, including the tag-release check. Only two jobs use macOS runners.
 
 **Rust job breakdown:**
 
 - **Lint:** 1 job (runs fmt, clippy, deny on stable)
-- **Build:** 15 jobs (3 rust versions × 5 platforms)
-- **Test:** 21 jobs (3 rust versions × 7 platform/libc combinations)
+- **Build:** 6 jobs (2 rust versions × 3 platforms)
+- **Test:** 10 jobs (2 rust versions × 5 platform/libc combinations)
   - Linux: 2 arch × 2 libc (glibc + musl) = 4 combinations
-  - macOS: 2 arch × 1 (native) = 2 combinations
   - Windows: 1 arch × 1 (native) = 1 combination
-  - Total: 7 combinations × 3 rust versions = 21 jobs
+  - Total: 5 combinations × 2 rust versions = 10 jobs
 
 ## CI Tooling
 
@@ -401,12 +440,12 @@ approval is enforced by the GitHub ruleset.
 
 ### Pre-commit Checks
 
-Pre-commit hooks run on all platform combinations.
+Pre-commit hooks run on the three enabled Linux/Windows platform combinations.
 See [Development > Pre-commit Hooks](development.md#pre-commit-hooks) for the full list of hooks.
 
 | Check | Tool | Run On |
 | ------- | ------ | -------- |
-| Pre-commit hooks | `pre-commit/action` | All 5 platform combinations |
+| Pre-commit hooks | `pre-commit` | All 3 check-platform combinations |
 
 ### Rust Checks
 
@@ -417,8 +456,8 @@ The Rust workflow is split into lint, build, and test stages:
 | Lint | Formatting | `cargo fmt --check` | 1 job (stable) |
 | Lint | Linting | `cargo clippy` | 1 job (stable) |
 | Lint | Dependency audit | `cargo deny` | 1 job (stable) |
-| Build | Compile + archive | `cargo nextest archive` | 15 jobs (3 rust × 5 platforms) |
-| Test | Run tests | `cargo-nextest run` | 21 jobs (3 rust × 7 platform/libc) |
+| Build | Compile + archive | `cargo nextest archive` | 6 jobs (2 rust × 3 platforms) |
+| Test | Run tests | `cargo-nextest run` | 10 jobs (2 rust × 5 platform/libc) |
 
 **Build/Test split rationale:** Linux binaries are built targeting musl (Rust provides
 built-in support with self-contained linking), then tested on both glibc (Ubuntu) and
@@ -430,14 +469,14 @@ musl (Alpine) environments to verify portability.
 
 | Check | Tool | Run On |
 | ------- | ------ | -------- |
-| Coverage | `cargo-llvm-cov` | Stable only, all 5 platforms |
+| Coverage | `cargo-llvm-cov` | Stable only, all 3 check platforms |
 | Upload | `codecov/codecov-action` | With OIDC authentication, `rust` flag |
 
 #### npm Coverage
 
 | Check | Tool | Run On |
 | ------- | ------ | -------- |
-| Coverage | `c8` (V8 native coverage) | Node.js 24, all 5 platforms |
+| Coverage | `c8` (V8 native coverage) | Node.js 24, all 3 check platforms |
 | Upload | `codecov/codecov-action` | With OIDC authentication, `npm` flag |
 
 Both Rust and npm coverage use Codecov flags to separate the coverage data. The `codecov.yml` configuration defines components for each, enabling per-component coverage tracking in PR comments.

--- a/docs/src/project/development.md
+++ b/docs/src/project/development.md
@@ -110,13 +110,17 @@ The CI workflow separates build and test stages:
 
 1. **Build stage**: Compiles tests and creates archives
    - Linux: Builds with musl target (Rust provides built-in support)
-   - macOS/Windows: Builds natively
+   - Windows: Builds natively
 
 2. **Test stage**: Runs pre-built tests in multiple environments
    - Linux tests run on both glibc (Ubuntu) and musl (Alpine)
-   - macOS/Windows tests run natively
+   - Windows tests run natively
 
 This architecture verifies that musl binaries work correctly on glibc systems and vice versa.
+
+macOS CI coverage consists of native Intel and ARM release builds and their
+`--version` smoke checks. The test matrix runs MSRV and stable Rust on Linux and
+Windows; beta is retained in the shared library with `enabled: false`.
 
 ### Test Runner
 


### PR DESCRIPTION
## Summary

Reduce CI runner demand with four focused changes:

- Cache Clippy dependencies and build artifacts in the pre-commit jobs, using a dedicated key to avoid collisions with coverage jobs.
- Retain beta in the shared library but disable it with a commented flag. Matrix generation filters disabled entries, and beta channel resolution is skipped while disabled.
- Make macOS build-only: keep native Intel and ARM release builds, their binary-version smoke checks, and both platforms' packaged artifacts. General checks and npm installation tests run on Linux and Windows.
- Warm mise caches once on each of the three check platforms before consumer jobs fan out, following the warmup pattern from gw/monorepo. The dry-run lockfile validator remains cache-free.

## Coverage and job counts

Counts exclude skipped jobs and include the new warmup jobs.

| Ordinary PR | Before | After |
| --- | ---: | ---: |
| Total jobs | 78 | 54 |
| macOS jobs | 22 | 2 |
| Rust build/archive jobs | 15 | 6 |
| Rust test jobs | 21 | 10 |
| Release binary builds | 5 | 5 |

Linux and Windows retain MSRV/stable tests, pre-commit, Rust/npm coverage, and npm installation checks. Linux still executes the static musl test binaries in both Ubuntu and Alpine environments. macOS coverage is compilation, linking, and binary launch on both native architectures.

The CI and development documentation describe the new coverage and warmup behavior.

## Validation

- Targeted pre-commit hooks passed, including actionlint, workflow/action schema validation, ShellCheck, YAML checks, Markdown/link checks, and the documentation build.
- Executed the matrix-loader shell and expanded all affected matrices: exactly two macOS jobs, both release builds; all five release artifacts retained.
- Verified that re-enabling the beta/macOS axis flags restores the original Rust build/test matrix sizes.
- Exercised the actual version-resolution script with mocked network responses: disabled beta makes no beta request; enabled beta produces the expected version.
- Checked warmup dependencies, matching mise action inputs, and the independent cache-disabled lockfile validator.

Runner-minute savings discussed during planning are estimates from previous runs; this PR's Actions run will provide the first measurement of the new configuration.
