### PR TITLE
Update syn lockfile to unblock Renovate clap update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2071,7 +2071,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2311,7 +2311,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update the shared syn 3.x lockfile entry from 3.0.0 to 3.0.2.
- Unblock Renovate's clap 4.6.6 update: its clap_derive dependency requires syn ^3.0.2, but Cargo's targeted clap update retains the shared syn 3.0.0 lock entry and fails resolution.
- Address the clap-related empty-commit warning and pending update reported on the Dependency Dashboard (#138).

## Validation

- `cargo check --locked --workspace`
- `cargo +1.89.0 check --locked --workspace` (project MSRV)
- `cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package clap@4.6.3 --precise 4.6.6 --dry-run` successfully resolves the clap, clap_builder, and clap_derive updates.
- `git diff --check`

After this PR is merged, rerun Renovate to create the clap update PR.
