### PR TITLE
Pin mise Node version to enable Renovate manifest updates

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ http_timeout = "120s"
 locked = true
 
 [tools]
-node = "24"
+node = "24.20.0"
 python = "3.14.7"
 "pipx:pre-commit" = "4.6.2"
 # Non-core tools: use explicit backend prefix (aqua:/github:) for Renovate compatibility


### PR DESCRIPTION
## Summary

- Declare the full Node version, 24.20.0, in mise.toml to match the existing lockfile.
- Let future Node updates use Renovate's manifest-update path, which can regenerate the lockfile for the new version.
- Work around the partial-selector lockfile-update limitation affecting the Node update on the Dependency Dashboard (#138).

The upstream behavior is tracked in https://github.com/renovatebot/renovate/discussions/44418, with an implementation proposed in https://github.com/renovatebot/renovate/pull/44615.

## Validation

- `mise install --locked --dry-run` passed.
- `git diff --check` passed.
- Confirmed the declaration matches the Node 24.20.0 entry in mise.lock.

After this PR is merged, rerun Renovate to let it propose the Node 24.21.0 update.
