### PR TITLE
Decouple OpenAPI request data from the Onshape client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,6 @@ version = "0.5.3-dev.0"
 dependencies = [
  "base64 0.23.1",
  "http",
- "onshape-client-core",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -37,8 +37,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use onshape_client_core::request::{ApiRequest, BinaryField, RequestBody};
 use onshape_openapi::OpenApiSpec;
+use onshape_openapi::request::{ApiRequest, BinaryField, MultipartBody, RequestBody};
 
 use crate::config::ResolvedAuth;
 use crate::{AuthStatusResult, ValidationState};
@@ -161,7 +161,7 @@ pub enum ToolEffect {
     /// After executing the request, the I/O layer calls [`resume()`] with
     /// the continuation and an [`IoResult::ApiResponse`].
     ApiRequest {
-        /// The HTTP request to execute.
+        /// Neutral HTTP request data, adapted to the Onshape client by the I/O layer.
         request: ApiRequest,
         /// What to do with the response.
         continuation: Continuation,
@@ -663,7 +663,7 @@ fn inject_into_json_field(
 ///
 /// Returns `Err(message)` on encoding/lookup errors.
 fn inject_into_multipart_field(
-    multipart: &mut onshape_client_core::request::MultipartBody,
+    multipart: &mut MultipartBody,
     file_ref: &FileReference,
     reads: &HashMap<PathBuf, &[u8]>,
 ) -> Result<(), String> {
@@ -5138,7 +5138,6 @@ mod tests {
 
     /// Build a minimal `ApiRequest` with a JSON body for injection tests.
     fn json_request_for_injection(body: Value) -> ApiRequest {
-        use onshape_client_core::request::RequestBody;
         ApiRequest {
             method: http::Method::POST,
             path: "/test".to_string(),
@@ -5253,7 +5252,6 @@ mod tests {
 
     /// Build a minimal `ApiRequest` with a multipart body for injection tests.
     fn multipart_request_for_injection(text_fields: Vec<(String, String)>) -> ApiRequest {
-        use onshape_client_core::request::{MultipartBody, RequestBody};
         ApiRequest {
             method: http::Method::POST,
             path: "/upload".to_string(),

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use http::{HeaderMap, HeaderName, HeaderValue};
-use onshape_client_core::request::RequestBody;
+use onshape_openapi::request::RequestBody;
 use onshape_openapi::{OpenApiSpec, SearchFilters};
 use rmcp::{
     ErrorData,

--- a/crates/onshape-mcp-core/src/tools/onshape.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use onshape_client_core::request::{ApiRequest, RequestBody};
+use onshape_openapi::request::{ApiRequest, RequestBody};
 use serde_json::{Map, Value};
 
 use super::FileReference;

--- a/crates/onshape-mcp-io/src/lib.rs
+++ b/crates/onshape-mcp-io/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod login;
 pub mod oauth;
 pub mod oauth_server;
+mod request;
 pub mod watcher;
 
 use std::path::PathBuf;
@@ -704,6 +705,7 @@ async fn dispatch_tool_effect(
                 request: api_req,
                 continuation,
             } => {
+                let api_req = request::into_onshape_request(api_req);
                 let raw = execute_raw_api_request(state, &api_req).await;
                 match raw {
                     Ok(raw) => {

--- a/crates/onshape-mcp-io/src/request.rs
+++ b/crates/onshape-mcp-io/src/request.rs
@@ -1,0 +1,141 @@
+//! Adapt neutral `OpenAPI` requests to the authenticated Onshape client.
+
+use onshape_client_core::request as client;
+use onshape_openapi::request as openapi;
+
+/// Move request data into the Onshape client representation without serialization.
+pub fn into_onshape_request(request: openapi::ApiRequest) -> client::ApiRequest {
+    let openapi::ApiRequest {
+        method,
+        path,
+        query_params,
+        headers,
+        body,
+        content_type,
+    } = request;
+
+    client::ApiRequest {
+        method,
+        path,
+        query_params,
+        headers,
+        body: body.map(into_onshape_body),
+        content_type,
+    }
+}
+
+/// Preserve JSON values, multipart field order, and binary part metadata.
+fn into_onshape_body(body: openapi::RequestBody) -> client::RequestBody {
+    match body {
+        openapi::RequestBody::Json(value) => client::RequestBody::Json(value),
+        openapi::RequestBody::Multipart(openapi::MultipartBody {
+            text_fields,
+            binary_fields,
+        }) => client::RequestBody::Multipart(client::MultipartBody {
+            text_fields,
+            binary_fields: binary_fields
+                .into_iter()
+                .map(
+                    |openapi::BinaryField {
+                         field_name,
+                         data,
+                         content_type,
+                     }| client::BinaryField {
+                        field_name,
+                        data,
+                        content_type,
+                    },
+                )
+                .collect(),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use http::{HeaderMap, HeaderValue, Method};
+    use serde_json::json;
+
+    fn request(
+        body: Option<openapi::RequestBody>,
+        content_type: Option<&str>,
+    ) -> openapi::ApiRequest {
+        let mut headers = HeaderMap::new();
+        headers.append("x-tag", HeaderValue::from_static("first"));
+        headers.append("x-tag", HeaderValue::from_static("second"));
+        openapi::ApiRequest {
+            method: Method::PATCH,
+            path: "/items/a%2Fb".into(),
+            query_params: vec![
+                ("tag".into(), "first".into()),
+                ("tag".into(), "second".into()),
+            ],
+            headers,
+            body,
+            content_type: content_type.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn conversion_preserves_request_shape_for_all_body_variants() {
+        for request in [
+            request(None, None),
+            request(
+                Some(openapi::RequestBody::Json(
+                    json!({ "title": "Example", "optional": null }),
+                )),
+                Some("application/json"),
+            ),
+            request(
+                Some(openapi::RequestBody::Multipart(openapi::MultipartBody {
+                    text_fields: vec![
+                        ("tag".into(), "first".into()),
+                        ("tag".into(), "second".into()),
+                    ],
+                    binary_fields: vec![
+                        openapi::BinaryField {
+                            field_name: "file".into(),
+                            data: vec![0, 128, 255],
+                            content_type: Some("application/octet-stream".into()),
+                        },
+                        openapi::BinaryField {
+                            field_name: "file".into(),
+                            data: vec![],
+                            content_type: None,
+                        },
+                    ],
+                })),
+                Some("multipart/form-data"),
+            ),
+        ] {
+            let expected = serde_json::to_value(&request).expect("serializable neutral request");
+            let converted = into_onshape_request(request);
+            assert_eq!(
+                serde_json::to_value(converted).expect("serializable client request"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn conversion_preserves_opaque_and_sensitive_header_values() {
+        let mut request = request(None, None);
+        let mut sensitive = HeaderValue::from_bytes(&[0x80]).expect("valid opaque header");
+        sensitive.set_sensitive(true);
+        request.headers.append("x-opaque", sensitive);
+        request.headers.append(
+            "x-opaque",
+            HeaderValue::from_bytes(&[0xff]).expect("valid opaque header"),
+        );
+
+        let converted = into_onshape_request(request);
+        let values: Vec<_> = converted.headers.get_all("x-opaque").iter().collect();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].as_bytes(), &[0x80]);
+        assert!(values[0].is_sensitive());
+        assert_eq!(values[1].as_bytes(), &[0xff]);
+        assert!(!values[1].is_sensitive());
+    }
+}

--- a/crates/onshape-openapi/Cargo.toml
+++ b/crates/onshape-openapi/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["api-bindings"]
 [dependencies]
 base64.workspace = true
 http.workspace = true
-onshape-client-core.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -6,8 +6,11 @@
 //! Standard component schema inspection lives in the internal `schema` module.
 //! The public API adds Onshape presentation through the `onshape` module when
 //! returning explanations; parsed schemas retain their original metadata.
+//! The [`request`] module owns API-neutral request data; applications adapt it
+//! to their HTTP executor at the I/O boundary.
 
 mod onshape;
+pub mod request;
 mod schema;
 
 use std::collections::{HashMap, HashSet};
@@ -20,8 +23,8 @@ use serde_json::Value;
 
 use crate::schema::SchemaCatalog;
 
-pub use onshape_client_core::request::ApiRequest;
-use onshape_client_core::request::{BinaryField, MultipartBody, RequestBody};
+pub use request::ApiRequest;
+use request::{BinaryField, MultipartBody, RequestBody};
 
 // ============================================================================
 // Error Types
@@ -451,7 +454,7 @@ impl OpenApiSpec {
         })
     }
 
-    /// Build an API request effect for a given endpoint.
+    /// Build a neutral API request for a given endpoint.
     ///
     /// Validates that required path parameters are provided and substitutes them
     /// into the path template. Query parameters, headers, and body are passed

--- a/crates/onshape-openapi/src/request.rs
+++ b/crates/onshape-openapi/src/request.rs
@@ -1,0 +1,245 @@
+//! API-neutral request data for `OpenAPI` request building and MCP effects.
+//!
+//! Requests contain relative paths, headers, query parameters, and body data.
+//! The application supplies the base URL, authentication, and I/O executor.
+
+use http::{HeaderMap, Method};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// `ApiRequest` serde is primarily for test and inspection ergonomics: internal
+// tests assert the request shape, and external consumers can serialize requests
+// in their own tests/debug tooling. Runtime request execution uses the typed
+// fields directly, so these helpers preserve that plain-data surface while the
+// boundary uses standard `http` types.
+mod method_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use super::Method;
+
+    pub fn serialize<S>(method: &Method, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(method.as_str())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Method, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Method::from_bytes(value.to_ascii_uppercase().as_bytes())
+            .map_err(|_| serde::de::Error::custom(format!("unknown HTTP method: {value}")))
+    }
+}
+
+// See `method_serde` for why `ApiRequest` keeps serde support around `http`
+// protocol types.
+mod request_headers_serde {
+    use std::str;
+
+    use http::{HeaderMap, HeaderName, HeaderValue};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(headers: &HeaderMap, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let pairs: Vec<(&str, &str)> = headers
+            .iter()
+            .map(|(name, value)| {
+                value
+                    .to_str()
+                    .map(|value| (name.as_str(), value))
+                    .map_err(serde::ser::Error::custom)
+            })
+            .collect::<Result<_, _>>()?;
+        pairs.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HeaderMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let pairs = Vec::<(String, String)>::deserialize(deserializer)?;
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            let name = HeaderName::from_bytes(name.as_bytes()).map_err(serde::de::Error::custom)?;
+            let value = HeaderValue::from_str(&value).map_err(serde::de::Error::custom)?;
+            headers.append(name, value);
+        }
+        Ok(headers)
+    }
+}
+
+// ============================================================================
+// API Request
+// ============================================================================
+
+/// An HTTP request produced by [`OpenApiSpec::build_request`](crate::OpenApiSpec::build_request).
+///
+/// This is a pure data structure describing what HTTP call to make.
+/// It does not include the base URL or authentication — those are added
+/// by the I/O layer when executing the request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiRequest {
+    /// HTTP method.
+    #[serde(with = "method_serde")]
+    pub method: Method,
+    /// Fully resolved URL path (path params substituted), e.g. `/items/abc123`.
+    pub path: String,
+    /// Query parameters.
+    pub query_params: Vec<(String, String)>,
+    /// Request headers supplied by the request builder.
+    #[serde(default, with = "request_headers_serde")]
+    pub headers: HeaderMap,
+    /// Request body, if any.
+    pub body: Option<RequestBody>,
+    /// Content type for the request body.
+    pub content_type: Option<String>,
+}
+
+// ============================================================================
+// Request Body
+// ============================================================================
+
+/// The body of an API request.
+///
+/// Different content types require different body representations. The I/O
+/// layer uses this to decide how to serialize and send the body.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RequestBody {
+    /// A JSON body — serialized via `serde_json`.
+    Json(Value),
+    /// A multipart form body — text fields plus binary file parts.
+    /// The I/O layer builds a `multipart/form-data` request from this.
+    Multipart(MultipartBody),
+}
+
+/// A multipart form body with text and binary parts.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MultipartBody {
+    /// Text form fields: `(field_name, value)`.
+    pub text_fields: Vec<(String, String)>,
+    /// Binary form fields (e.g., file uploads).
+    pub binary_fields: Vec<BinaryField>,
+}
+
+/// A single binary field in a multipart form.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BinaryField {
+    /// The form field name (must match the schema property name).
+    pub field_name: String,
+    /// The raw binary content.
+    pub data: Vec<u8>,
+    /// Optional MIME type for this part (e.g., `application/octet-stream`).
+    pub content_type: Option<String>,
+}
+
+impl RequestBody {
+    /// Convenience: extract the inner [`Value`] if this is a `Json` variant.
+    ///
+    /// Returns `None` for non-JSON variants.
+    #[must_use]
+    pub const fn as_json(&self) -> Option<&Value> {
+        match self {
+            Self::Json(v) => Some(v),
+            Self::Multipart(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use http::HeaderValue;
+    use serde_json::json;
+
+    #[test]
+    fn request_round_trip_preserves_body_shapes_and_repeated_parameters() {
+        for (body, content_type) in [
+            (Value::Null, Value::Null),
+            (
+                json!({ "Json": { "title": "Example", "optional": null } }),
+                json!("application/json"),
+            ),
+            (
+                json!({ "Multipart": {
+                    "text_fields": [["tag", "first"], ["tag", "second"]],
+                    "binary_fields": [{
+                        "field_name": "file",
+                        "data": [0, 128, 255],
+                        "content_type": "application/octet-stream"
+                    }]
+                } }),
+                json!("multipart/form-data"),
+            ),
+        ] {
+            let encoded = json!({
+                "method": "POST",
+                "path": "/items/a%2Fb",
+                "query_params": [["tag", "first"], ["tag", "second"]],
+                "headers": [["x-tag", "first"], ["x-tag", "second"]],
+                "body": body,
+                "content_type": content_type
+            });
+            let request: ApiRequest =
+                serde_json::from_value(encoded.clone()).expect("valid request");
+            assert_eq!(
+                serde_json::to_value(&request).expect("serializable request"),
+                encoded
+            );
+            assert_eq!(
+                request.body.as_ref().and_then(RequestBody::as_json),
+                body.get("Json")
+            );
+        }
+    }
+
+    #[test]
+    fn request_deserialization_defaults_headers_and_normalizes_methods() {
+        for (input, expected) in [("pAtCh", "PATCH"), ("custom-verb", "CUSTOM-VERB")] {
+            let request: ApiRequest = serde_json::from_value(json!({
+                "method": input,
+                "path": "/items",
+                "query_params": []
+            }))
+            .expect("request without headers or body should parse");
+            assert_eq!(request.method.as_str(), expected);
+            assert!(request.headers.is_empty());
+            assert!(request.body.is_none());
+            assert!(request.content_type.is_none());
+        }
+    }
+
+    #[test]
+    fn request_deserialization_rejects_invalid_methods_and_headers() {
+        for (field, value) in [
+            ("method", json!("bad method")),
+            ("headers", json!([["bad header", "value"]])),
+            ("headers", json!([["x-test", "bad\nvalue"]])),
+        ] {
+            let mut encoded = json!({ "method": "GET", "path": "/items", "query_params": [] });
+            encoded[field] = value;
+            assert!(serde_json::from_value::<ApiRequest>(encoded).is_err());
+        }
+    }
+
+    #[test]
+    fn request_serialization_rejects_non_text_header_values() {
+        let request = ApiRequest {
+            method: Method::GET,
+            path: "/items".into(),
+            query_params: vec![],
+            headers: HeaderMap::from_iter([(
+                http::HeaderName::from_static("x-opaque"),
+                HeaderValue::from_bytes(&[0x80]).expect("valid opaque header"),
+            )]),
+            body: None,
+            content_type: None,
+        };
+        assert!(serde_json::to_value(&request).is_err());
+    }
+}


### PR DESCRIPTION
OpenAPI request building depended on `onshape-client-core` solely for request and body types, pulling Onshape authentication dependencies into the spec crate. Define neutral `ApiRequest`, `RequestBody`, `MultipartBody`, and `BinaryField` data in `onshape-openapi::request` and remove that dependency.

MCP effects and file injection now carry the neutral types. The shared I/O dispatcher converts them into the existing Onshape client representation before authenticated execution. The owned conversion preserves headers, ordered query parameters, JSON values, multipart fields, binary bytes, and content types without serialization.

This changes Rust type identity: `onshape_openapi::ApiRequest` and `OpenApiSpec::build_request` now use the spec crate's own request type. The MCP boundary is adapted in this PR. Tool names, schemas, response behavior, and authentication behavior are preserved.

Validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` — 641 tests passed, including doctests.
- `cargo test -p onshape-openapi --locked` — 52 tests passed independently.
- `cargo tree -p onshape-openapi --locked --edges normal` confirms the spec crate has no dependency on Onshape client or MCP crates.

New tests cover request serialization compatibility and conversion of every body variant, including repeated parameters, opaque and sensitive headers, and multipart binary metadata.
