### PR TITLE
Isolate generic API tool execution from Onshape dispatch

### DIFF
--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -5,9 +5,9 @@
 //!
 //! Onshape request validation and diagnostic interpretation live in the private
 //! `onshape` module. The private `api` module handles `OpenAPI` search, explain,
-//! schema lookup, and request preparation, with validation supplied by this
-//! dispatcher. Tool metadata, shared effects, file injection, and HTTP status
-//! classification remain here.
+//! schema lookup, and execution through its own effects and continuations.
+//! The Onshape adapter supplies validation and diagnostic policy and translates
+//! generic effects into the public dispatcher types used by the I/O layer.
 //!
 //! ## Effect Pattern
 //!
@@ -38,7 +38,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use onshape_openapi::OpenApiSpec;
-use onshape_openapi::request::{ApiRequest, BinaryField, MultipartBody, RequestBody};
+use onshape_openapi::request::ApiRequest;
+#[cfg(test)]
+use onshape_openapi::request::{MultipartBody, RequestBody};
+
+pub use api::{FileEncoding, FileRead, FileReadResult, FileReference};
+use api::{parse_arguments, validate_file_path};
 
 use crate::config::ResolvedAuth;
 use crate::{AuthStatusResult, ValidationState};
@@ -79,37 +84,6 @@ pub enum FileWriteResult {
         path: PathBuf,
     },
     /// The file write failed.
-    Error {
-        /// The path that was attempted.
-        path: PathBuf,
-        /// Human-readable error message.
-        message: String,
-    },
-}
-
-// ============================================================================
-// File Read Effect Types
-// ============================================================================
-
-/// A file to be read from disk by the I/O layer.
-///
-/// This is a pure data description of the read — no I/O is performed here.
-#[derive(Debug)]
-pub struct FileRead {
-    /// The file path to read.
-    pub path: PathBuf,
-}
-
-/// The outcome of a single file read attempt, reported by the I/O layer.
-pub enum FileReadResult {
-    /// The file was read successfully.
-    Success {
-        /// The path that was read.
-        path: PathBuf,
-        /// The raw file contents.
-        data: Vec<u8>,
-    },
-    /// The file read failed.
     Error {
         /// The path that was attempted.
         path: PathBuf,
@@ -281,78 +255,6 @@ fn tool_input_error(message: impl Into<String>) -> ToolEffect {
     )])))
 }
 
-/// Validate a file path for use in file I/O effects.
-///
-/// Returns `Ok(PathBuf)` if the path is valid. Returns `Err(message)` if:
-/// - The path is empty or whitespace-only
-/// - The path has no file name component
-/// - The path contains `..` segments (directory traversal)
-fn validate_file_path(path: &str) -> Result<PathBuf, String> {
-    let path_buf = PathBuf::from(path);
-    if path.trim().is_empty() || path_buf.file_name().is_none() {
-        return Err(format!("file path must include a file name: {path:?}"));
-    }
-    if path_buf
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(format!(
-            "file path must not contain '..' segments: {path:?}"
-        ));
-    }
-    Ok(path_buf)
-}
-
-const fn http_error_category(status: u16) -> &'static str {
-    match status {
-        400 | 422 => "invalid_request",
-        401 => "authentication",
-        403 => "permission",
-        404 => "not_found",
-        408 => "timeout",
-        409 => "conflict",
-        429 => "rate_limited",
-        502..=504 => "service_unavailable",
-        400..=499 => "client_error",
-        500..=599 => "server_error",
-        _ => "http_error",
-    }
-}
-
-const fn http_error_is_transient(status: u16) -> bool {
-    matches!(status, 408 | 425 | 429 | 500 | 502..=504)
-}
-
-fn retry_after_seconds(headers: &[(String, String)]) -> Option<u64> {
-    const MAX_RETRY_AFTER_SECONDS: u64 = 86_400;
-
-    headers
-        .iter()
-        .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
-        .map(|(_, value)| value.trim_matches([' ', '\t']))
-        .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|seconds| *seconds <= MAX_RETRY_AFTER_SECONDS)
-}
-
-/// Combine generic HTTP classification with allowlisted Onshape response details.
-fn sanitized_api_error(status: u16, headers: &[(String, String)], body: &[u8]) -> String {
-    use std::fmt::Write;
-
-    let transient = http_error_is_transient(status);
-    let mut detail = format!(
-        "API error (HTTP {status}): category={}; transient={transient}",
-        http_error_category(status)
-    );
-
-    onshape::append_api_error_details(&mut detail, body);
-    if transient && let Some(seconds) = retry_after_seconds(headers) {
-        let _ = write!(detail, "; retry_after_seconds={seconds}");
-    }
-
-    detail
-}
-
 /// Convert a raw HTTP response from the Onshape API into a [`CallToolResult`].
 ///
 /// # Arguments
@@ -369,95 +271,7 @@ pub fn process_api_response(
     headers: &[(String, String)],
     body: &[u8],
 ) -> Result<CallToolResult, ErrorData> {
-    let is_success = (200..300).contains(&status);
-    if !is_success {
-        return Ok(CallToolResult::error(vec![ContentBlock::text(
-            sanitized_api_error(status, headers, body),
-        )]));
-    }
-
-    let body_text = match std::str::from_utf8(body) {
-        Ok(text) if response_content_type(headers).is_none_or(content_type_is_textual) => text,
-        _ => {
-            let content = binary_api_response_content(status, headers, body)?;
-            return Ok(CallToolResult::success(vec![content]));
-        }
-    };
-
-    // Try to parse as JSON for nice formatting
-    let content = if let Ok(json_val) = serde_json::from_str::<Value>(body_text) {
-        // LCOV_EXCL_START — serde_json::Value is always serializable as JSON content.
-        ContentBlock::json(&json_val).map_err(|e| {
-            ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                format!("failed to serialize API response: {e}"),
-                None,
-            )
-        })?
-        // LCOV_EXCL_STOP
-    } else {
-        ContentBlock::text(body_text)
-    };
-
-    Ok(CallToolResult::success(vec![content]))
-}
-
-fn response_content_type(headers: &[(String, String)]) -> Option<&str> {
-    headers
-        .iter()
-        .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))
-        .map(|(_, value)| value.as_str())
-}
-
-fn content_type_is_textual(content_type: &str) -> bool {
-    let media_type = content_type
-        .split(';')
-        .next()
-        .unwrap_or(content_type)
-        .trim()
-        .to_ascii_lowercase();
-
-    media_type.starts_with("text/")
-        || media_type == "application/json"
-        || media_type.ends_with("+json")
-        || media_type == "application/xml"
-        || media_type.ends_with("+xml")
-        || media_type == "application/javascript"
-        || media_type == "application/x-www-form-urlencoded"
-}
-
-fn binary_api_response_content(
-    status: u16,
-    headers: &[(String, String)],
-    body: &[u8],
-) -> Result<ContentBlock, ErrorData> {
-    let engine = base64::engine::general_purpose::STANDARD;
-    let mut response = serde_json::json!({
-        "status": status,
-        "byteLength": body.len(),
-    });
-
-    if let Some(response) = response.as_object_mut() {
-        response.insert("encoding".to_string(), Value::String("base64".to_string()));
-        response.insert("body".to_string(), Value::String(engine.encode(body)));
-    }
-
-    if let Some(content_type) = response_content_type(headers)
-        && let Some(response) = response.as_object_mut()
-    {
-        response.insert(
-            "contentType".to_string(),
-            Value::String(content_type.to_string()),
-        );
-    }
-
-    ContentBlock::json(&response).map_err(|e| {
-        ErrorData::new(
-            ErrorCode::INTERNAL_ERROR,
-            format!("failed to serialize binary API response metadata: {e}"),
-            None,
-        )
-    })
+    api::process_api_response(status, headers, body, &onshape::API_POLICY)
 }
 
 /// Resume a multi-step tool operation after the I/O layer has executed an effect.
@@ -483,7 +297,14 @@ pub fn resume(continuation: Continuation, result: IoResult<'_>) -> (ToolEffect, 
                 body,
             },
         ) => (
-            ToolEffect::Done(process_api_response(status, headers, body)),
+            onshape::resume_api(
+                api::Continuation::FormatApiResponse,
+                api::IoResult::ApiResponse {
+                    status,
+                    headers,
+                    body,
+                },
+            ),
             vec![],
         ),
 
@@ -534,7 +355,13 @@ pub fn resume(continuation: Continuation, result: IoResult<'_>) -> (ToolEffect, 
         (
             Continuation::InjectFilesIntoRequest { request, file_refs },
             IoResult::FileReadResults(results),
-        ) => (resume_inject_files(request, &file_refs, results), vec![]),
+        ) => (
+            onshape::resume_api(
+                api::Continuation::InjectFilesIntoRequest { request, file_refs },
+                api::IoResult::FileReadResults(results),
+            ),
+            vec![],
+        ),
 
         // --- Mismatched continuation/result ---
         (continuation, result) => {
@@ -549,165 +376,6 @@ pub fn resume(continuation: Continuation, result: IoResult<'_>) -> (ToolEffect, 
             )
         }
     }
-}
-
-/// Inject file content into an API request body after file reads complete.
-///
-/// Extracted from [`resume()`] for readability.
-///
-/// Handles both JSON and multipart request bodies:
-///
-/// - **JSON**: injects content as string values at top-level keys.
-///   [`FileEncoding::TextUtf8`] produces a UTF-8 string, [`FileEncoding::Base64`]
-///   produces a base64-encoded string, and [`FileEncoding::RawBytes`] is an error.
-/// - **Multipart**: [`FileEncoding::RawBytes`] adds a binary form field,
-///   [`FileEncoding::TextUtf8`] adds a text form field, and
-///   [`FileEncoding::Base64`] adds a text form field with base64 content.
-#[allow(clippy::too_many_lines)]
-fn resume_inject_files(
-    mut request: ApiRequest,
-    file_refs: &[FileReference],
-    results: &[FileReadResult],
-) -> ToolEffect {
-    // Build a map from path → data for successful reads.
-    let mut reads: HashMap<PathBuf, &[u8]> = HashMap::new();
-    for result in results {
-        match result {
-            FileReadResult::Success { path, data } => {
-                reads.insert(path.clone(), data);
-            }
-            FileReadResult::Error { path, message } => {
-                return tool_input_error(format!(
-                    "failed to read file {}: {message}",
-                    path.display()
-                ));
-            }
-        }
-    }
-
-    let Some(body) = request.body.as_mut() else {
-        return tool_input_error("file_refs provided but the endpoint has no request body");
-    };
-
-    match body {
-        RequestBody::Json(value) => {
-            let Some(obj) = value.as_object_mut() else {
-                return tool_input_error("file_refs require the request body to be a JSON object");
-            };
-
-            for file_ref in file_refs {
-                if let Err(e) = inject_into_json_field(obj, file_ref, &reads) {
-                    return tool_input_error(e);
-                }
-            }
-        }
-
-        RequestBody::Multipart(multipart) => {
-            for file_ref in file_refs {
-                if let Err(e) = inject_into_multipart_field(multipart, file_ref, &reads) {
-                    return tool_input_error(e);
-                }
-            }
-        }
-    }
-
-    if let Err(message) = onshape::validate_injected_request(&request) {
-        return tool_input_error(message);
-    }
-
-    ToolEffect::ApiRequest {
-        request,
-        continuation: Continuation::FormatApiResponse,
-    }
-}
-
-/// Inject a single file reference into a JSON object field.
-///
-/// Returns `Err(message)` on encoding/lookup errors.
-fn inject_into_json_field(
-    obj: &mut Map<String, Value>,
-    file_ref: &FileReference,
-    reads: &HashMap<PathBuf, &[u8]>,
-) -> Result<(), String> {
-    let path = PathBuf::from(&file_ref.path);
-    let Some(data) = reads.get(&path) else {
-        return Err(format!(
-            "no read result for file reference: {}",
-            file_ref.path
-        ));
-    };
-
-    match file_ref.encoding {
-        FileEncoding::TextUtf8 => {
-            let text = std::str::from_utf8(data)
-                .map_err(|e| format!("file {} is not valid UTF-8: {e}", file_ref.path))?;
-            obj.insert(file_ref.field.clone(), Value::String(text.to_owned()));
-        }
-        FileEncoding::Base64 => {
-            let engine = base64::engine::general_purpose::STANDARD;
-            let encoded = engine.encode(data);
-            obj.insert(file_ref.field.clone(), Value::String(encoded));
-        }
-        FileEncoding::RawBytes => {
-            return Err(format!(
-                "file_ref for field {:?} uses raw_bytes encoding, which cannot \
-                 be used with JSON request bodies. Use text_utf8 or base64 instead.",
-                file_ref.field
-            ));
-        }
-    }
-    Ok(())
-}
-
-/// Inject a single file reference into a multipart form body.
-///
-/// Returns `Err(message)` on encoding/lookup errors.
-fn inject_into_multipart_field(
-    multipart: &mut MultipartBody,
-    file_ref: &FileReference,
-    reads: &HashMap<PathBuf, &[u8]>,
-) -> Result<(), String> {
-    let path = PathBuf::from(&file_ref.path);
-    let Some(data) = reads.get(&path) else {
-        return Err(format!(
-            "no read result for file reference: {}",
-            file_ref.path
-        ));
-    };
-
-    // Strip any existing entries for this field so file_ref wins
-    // (matches JSON path semantics where Map::insert replaces).
-    multipart
-        .text_fields
-        .retain(|(name, _)| name != &file_ref.field);
-    multipart
-        .binary_fields
-        .retain(|f| f.field_name != file_ref.field);
-
-    match file_ref.encoding {
-        FileEncoding::RawBytes => {
-            multipart.binary_fields.push(BinaryField {
-                field_name: file_ref.field.clone(),
-                data: data.to_vec(),
-                content_type: None,
-            });
-        }
-        FileEncoding::TextUtf8 => {
-            let text = std::str::from_utf8(data)
-                .map_err(|e| format!("file {} is not valid UTF-8: {e}", file_ref.path))?;
-            multipart
-                .text_fields
-                .push((file_ref.field.clone(), text.to_owned()));
-        }
-        FileEncoding::Base64 => {
-            let engine = base64::engine::general_purpose::STANDARD;
-            let encoded = engine.encode(data);
-            multipart
-                .text_fields
-                .push((file_ref.field.clone(), encoded));
-        }
-    }
-    Ok(())
 }
 
 /// Process auth validation API response.
@@ -907,7 +575,7 @@ pub fn call_tool(
                 Ok(s) => s,
                 Err(e) => return ToolEffect::Done(Err(e)),
             };
-            api::call(arguments, spec, onshape::validate_call_body)
+            onshape::adapt_api_effect(api::call(arguments, spec, &onshape::API_POLICY))
         }
         "onshape_api_schema" => {
             let spec = match require_spec(spec) {
@@ -971,54 +639,6 @@ pub struct ApiSearchInput {
 pub struct ApiExplainInput {
     /// The operation ID of the endpoint to explain (from search results).
     pub endpoint: String,
-}
-
-/// How file content should be encoded when injected into a request body.
-///
-/// The encoding determines how raw file bytes are converted for the target
-/// field. The appropriate encoding depends on the field type:
-///
-/// - **Text fields** (JSON string values, multipart text parts): use [`TextUtf8`](FileEncoding::TextUtf8)
-/// - **Binary fields** (multipart `format: binary` parts): use [`RawBytes`](FileEncoding::RawBytes)
-/// - **Embedded binary in JSON**: use [`Base64`](FileEncoding::Base64)
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum FileEncoding {
-    /// Read the file as UTF-8 text.
-    ///
-    /// For JSON bodies: injected as a JSON string value.
-    /// For multipart bodies: injected as a text form field.
-    ///
-    /// Returns an error if the file is not valid UTF-8.
-    TextUtf8,
-    /// Read the file as raw bytes and base64-encode.
-    ///
-    /// For JSON bodies: injected as a base64-encoded JSON string value.
-    /// For multipart bodies: injected as a text form field containing base64.
-    Base64,
-    /// Read the file as raw bytes (no encoding).
-    ///
-    /// For multipart bodies: injected as a binary form field (`BinaryField`).
-    /// For JSON bodies: returns an error (raw bytes cannot be embedded in JSON).
-    RawBytes,
-}
-
-/// A reference to a file whose content should be injected into a request body field.
-///
-/// Instead of the LLM reading a file into its context and inlining the content,
-/// the server reads the file at execution time. This keeps large file content
-/// out of the LLM's context window.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct FileReference {
-    /// File system path to read. Must not be empty or contain `..` segments.
-    pub path: String,
-    /// The body field name to populate with the file content.
-    ///
-    /// For JSON bodies, this is a top-level key in the JSON object.
-    /// For multipart bodies, this is the form field name.
-    pub field: String,
-    /// How to encode the file content for the target field.
-    pub encoding: FileEncoding,
 }
 
 /// Input schema for `onshape_api_call`.
@@ -1868,22 +1488,6 @@ fn format_screenshot_result(
 /// Unwrap the `OpenAPI` spec reference or return an internal error.
 fn require_spec(spec: Option<&OpenApiSpec>) -> Result<&OpenApiSpec, ErrorData> {
     spec.ok_or_else(|| ErrorData::new(ErrorCode::INTERNAL_ERROR, "OpenAPI spec not loaded", None))
-}
-
-/// Parse tool arguments from the MCP request into a typed struct.
-fn parse_arguments<T: serde::de::DeserializeOwned>(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<T, ErrorData> {
-    let args_value =
-        arguments.map_or_else(|| Value::Object(Map::new()), |m| Value::Object(m.clone()));
-
-    serde_json::from_value(args_value).map_err(|e| {
-        ErrorData::new(
-            ErrorCode::INVALID_PARAMS,
-            format!("invalid arguments: {e}"),
-            None,
-        )
-    })
 }
 
 // ============================================================================

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -1,7 +1,16 @@
 //! Pure `OpenAPI` tool handlers.
 //!
-//! The host supplies endpoint-specific body validation. Tool names, descriptions,
-//! public input types, and shared I/O effects are owned by the parent module.
+//! The `execution` module owns generic effects, file injection, and response
+//! formatting. The host supplies validation and diagnostic policy. Tool metadata
+//! and the four tool input schemas are owned by the parent module.
+
+mod execution;
+
+use execution::tool_input_error;
+pub(super) use execution::{
+    Continuation, Effect, IoResult, Policy, process_api_response, resume, validate_file_path,
+};
+pub use execution::{FileEncoding, FileRead, FileReadResult, FileReference};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -15,13 +24,7 @@ use rmcp::{
 };
 use serde_json::{Map, Value};
 
-use super::{
-    ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput, Continuation, FileEncoding,
-    FileRead, FileReference, ToolEffect, parse_arguments, tool_input_error, validate_file_path,
-};
-
-/// Host validation of the decoded body before request construction and file reads.
-pub(super) type BodyValidator = fn(&str, Option<&Value>, &[FileReference]) -> Result<(), String>;
+use super::{ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput};
 
 pub(super) fn search(
     arguments: Option<&Map<String, Value>>,
@@ -81,8 +84,8 @@ pub(super) fn explain(
 pub(super) fn call(
     arguments: Option<&Map<String, Value>>,
     spec: &OpenApiSpec,
-    validate_body: BodyValidator,
-) -> ToolEffect {
+    policy: &Policy,
+) -> Effect {
     if arguments
         .and_then(|arguments| arguments.get("body"))
         .is_some_and(Value::is_null)
@@ -109,7 +112,7 @@ pub(super) fn call(
         );
     }
 
-    if let Err(message) = validate_body(&input.endpoint, body.as_ref(), &input.file_refs) {
+    if let Err(message) = (policy.validate_body)(&input.endpoint, body.as_ref(), &input.file_refs) {
         return tool_input_error(message);
     }
 
@@ -174,7 +177,7 @@ pub(super) fn call(
     // After reads complete, resume() will inject the content and forward
     // the request as an ApiRequest effect.
     if input.file_refs.is_empty() {
-        ToolEffect::ApiRequest {
+        Effect::ApiRequest {
             request,
             continuation: Continuation::FormatApiResponse,
         }
@@ -189,7 +192,7 @@ pub(super) fn call(
             })
             .collect();
 
-        ToolEffect::ReadFiles {
+        Effect::ReadFiles {
             reads,
             continuation: Continuation::InjectFilesIntoRequest {
                 request,
@@ -239,11 +242,209 @@ fn header_params_to_header_map(params: &HashMap<String, String>) -> Result<Heade
     Ok(headers)
 }
 
+/// Parse tool arguments from the MCP request into a typed struct.
+pub(super) fn parse_arguments<T: serde::de::DeserializeOwned>(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<T, ErrorData> {
+    let args_value =
+        arguments.map_or_else(|| Value::Object(Map::new()), |m| Value::Object(m.clone()));
+
+    serde_json::from_value(args_value).map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("invalid arguments: {e}"),
+            None,
+        )
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
+    use super::execution::BodyValidator;
     use super::*;
     use serde_json::json;
+
+    fn policy(validate_body: BodyValidator) -> Policy {
+        Policy {
+            validate_body,
+            validate_request: |_| Ok(()),
+            append_error_details: |_, _| {},
+        }
+    }
+
+    fn file_upload_arguments() -> Value {
+        json!({
+            "endpoint": "createDocument",
+            "body": { "title": "Example" },
+            "file_refs": [{
+                "path": "content.txt",
+                "field": "content",
+                "encoding": "text_utf8"
+            }]
+        })
+    }
+
+    #[test]
+    fn generic_file_read_request_response_flow() {
+        let spec = document_store_spec();
+        let arguments = file_upload_arguments();
+        let host_policy = policy(|_, _, _| Ok(()));
+        let Effect::ReadFiles {
+            reads,
+            continuation,
+        } = call(arguments.as_object(), &spec, &host_policy)
+        else {
+            panic!("file references should schedule file reads");
+        };
+        assert_eq!(reads.len(), 1);
+        assert_eq!(reads[0].path, PathBuf::from("content.txt"));
+
+        let results = [FileReadResult::Success {
+            path: reads[0].path.clone(),
+            data: b"Uploaded content".to_vec(),
+        }];
+        let Effect::ApiRequest {
+            request,
+            continuation,
+        } = resume(
+            continuation,
+            IoResult::FileReadResults(&results),
+            &host_policy,
+        )
+        else {
+            panic!("file injection should produce an API request");
+        };
+        assert_eq!(request.method, http::Method::POST);
+        assert_eq!(request.path, "/documents");
+        assert_eq!(
+            request.body.as_ref().and_then(RequestBody::as_json),
+            Some(&json!({ "title": "Example", "content": "Uploaded content" }))
+        );
+
+        let response = br#"{"id":"item-1"}"#;
+        let headers = [("content-type".into(), "application/json".into())];
+        let Effect::Done(Ok(result)) = resume(
+            continuation,
+            IoResult::ApiResponse {
+                status: 201,
+                headers: &headers,
+                body: response,
+            },
+            &host_policy,
+        ) else {
+            panic!("the API response should complete the tool call");
+        };
+        assert_ne!(result.is_error, Some(true));
+        assert_eq!(result.content.len(), 1);
+        let text = &result.content[0].as_text().expect("JSON text content").text;
+        assert_eq!(
+            serde_json::from_str::<Value>(text).expect("valid JSON"),
+            json!({ "id": "item-1" })
+        );
+    }
+
+    #[test]
+    fn host_validation_rejects_injected_request_before_http_execution() {
+        let spec = document_store_spec();
+        let arguments = file_upload_arguments();
+        let mut host_policy = policy(|_, _, _| Ok(()));
+        host_policy.validate_request = |request| {
+            assert_eq!(request.method, http::Method::POST);
+            assert_eq!(request.path, "/documents");
+            assert_eq!(
+                request.body.as_ref().and_then(RequestBody::as_json),
+                Some(&json!({ "title": "Example", "content": "Rejected content" }))
+            );
+            Err("host rejected injected request".into())
+        };
+        let Effect::ReadFiles { continuation, .. } =
+            call(arguments.as_object(), &spec, &host_policy)
+        else {
+            panic!("file references should schedule file reads");
+        };
+        let results = [FileReadResult::Success {
+            path: PathBuf::from("content.txt"),
+            data: b"Rejected content".to_vec(),
+        }];
+        let Effect::Done(Ok(result)) = resume(
+            continuation,
+            IoResult::FileReadResults(&results),
+            &host_policy,
+        ) else {
+            panic!("host rejection must prevent HTTP execution");
+        };
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(
+            result.content[0].as_text().expect("text diagnostic").text,
+            "host rejected injected request"
+        );
+    }
+
+    #[test]
+    fn error_response_uses_host_details_and_generic_retry_guidance() {
+        let mut enriched_policy = policy(|_, _, _| Ok(()));
+        enriched_policy.append_error_details = |detail, body| {
+            assert_eq!(body, b"private response payload");
+            detail.push_str("; host_code=BUSY");
+        };
+        let headers = [("retry-after".into(), "30".into())];
+        for (host_policy, extra) in [
+            (policy(|_, _, _| Ok(())), ""),
+            (enriched_policy, "; host_code=BUSY"),
+        ] {
+            let Effect::Done(Ok(result)) = resume(
+                Continuation::FormatApiResponse,
+                IoResult::ApiResponse {
+                    status: 429,
+                    headers: &headers,
+                    body: b"private response payload",
+                },
+                &host_policy,
+            ) else {
+                panic!("an HTTP error should complete with a tool error");
+            };
+            assert_eq!(result.is_error, Some(true));
+            assert_eq!(
+                result.content[0].as_text().expect("text diagnostic").text,
+                format!(
+                    "API error (HTTP 429): category=rate_limited; transient=true{extra}; retry_after_seconds=30"
+                )
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "mismatched Continuation and IoResult")]
+    fn response_continuation_rejects_file_results() {
+        let _ = resume(
+            Continuation::FormatApiResponse,
+            IoResult::FileReadResults(&[]),
+            &policy(|_, _, _| Ok(())),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "mismatched Continuation and IoResult")]
+    fn file_continuation_rejects_http_response() {
+        let spec = document_store_spec();
+        let arguments = file_upload_arguments();
+        let host_policy = policy(|_, _, _| Ok(()));
+        let Effect::ReadFiles { continuation, .. } =
+            call(arguments.as_object(), &spec, &host_policy)
+        else {
+            panic!("file references should schedule file reads");
+        };
+        let _ = resume(
+            continuation,
+            IoResult::ApiResponse {
+                status: 200,
+                headers: &[],
+                body: b"",
+            },
+            &host_policy,
+        );
+    }
 
     fn document_store_spec() -> OpenApiSpec {
         OpenApiSpec::from_json(
@@ -282,10 +483,10 @@ mod tests {
         let body = json!({ "title": "Example" });
         let arguments = json!({ "endpoint": "createDocument", "body": body });
 
-        let ToolEffect::ApiRequest {
+        let Effect::ApiRequest {
             request,
             continuation: Continuation::FormatApiResponse,
-        } = call(arguments.as_object(), &spec, |_, _, _| Ok(()))
+        } = call(arguments.as_object(), &spec, &policy(|_, _, _| Ok(())))
         else {
             panic!("a permissive host should allow the document store request");
         };
@@ -311,7 +512,8 @@ mod tests {
             }]
         });
 
-        let ToolEffect::Done(Ok(result)) = call(arguments.as_object(), &spec, |_, _, _| Ok(()))
+        let Effect::Done(Ok(result)) =
+            call(arguments.as_object(), &spec, &policy(|_, _, _| Ok(())))
         else {
             panic!("a traversal path must not schedule file reads");
         };
@@ -335,7 +537,7 @@ mod tests {
             }]
         });
 
-        let effect = call(arguments.as_object(), &spec, |endpoint, body, file_refs| {
+        let host_policy = policy(|endpoint, body, file_refs| {
             assert_eq!(endpoint, "createDocument");
             assert_eq!(body, Some(&json!({ "title": "Example" })));
             assert_eq!(file_refs.len(), 1);
@@ -344,8 +546,9 @@ mod tests {
             assert!(matches!(file_refs[0].encoding, FileEncoding::TextUtf8));
             Err("host rejected document".into())
         });
+        let effect = call(arguments.as_object(), &spec, &host_policy);
 
-        let ToolEffect::Done(Ok(result)) = effect else {
+        let Effect::Done(Ok(result)) = effect else {
             panic!("host rejection should return a tool error before scheduling I/O");
         };
         assert_eq!(result.is_error, Some(true));

--- a/crates/onshape-mcp-core/src/tools/api/execution.rs
+++ b/crates/onshape-mcp-core/src/tools/api/execution.rs
@@ -1,0 +1,546 @@
+//! Generic API effects, file injection, and response formatting.
+//!
+//! The host supplies synchronous validation and diagnostic policy on each call.
+//! Effects and continuations contain only data, with no authentication or I/O.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use base64::Engine;
+use onshape_openapi::request::{ApiRequest, BinaryField, MultipartBody, RequestBody};
+use rmcp::{
+    ErrorData,
+    model::{CallToolResult, ContentBlock, ErrorCode},
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Host validation of the decoded body before request construction and file reads.
+pub type BodyValidator = fn(&str, Option<&Value>, &[FileReference]) -> Result<(), String>;
+
+/// Synchronous host policy, supplied separately from plain-data continuations.
+pub struct Policy {
+    /// Validate the decoded body before generic file and request validation.
+    pub validate_body: BodyValidator,
+    /// Validate the final request after file contents have been injected.
+    pub validate_request: fn(&ApiRequest) -> Result<(), String>,
+    /// Append host-approved details to a generic HTTP error diagnostic.
+    pub append_error_details: fn(&mut String, &[u8]),
+}
+
+/// A generic tool result or I/O operation to execute.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Effect {
+    /// The tool completed.
+    Done(Result<CallToolResult, ErrorData>),
+    /// Execute a neutral API request, then resume with its response.
+    ApiRequest {
+        /// The request to execute.
+        request: ApiRequest,
+        /// How to process the response.
+        continuation: Continuation,
+    },
+    /// Read local files, then resume with their contents.
+    ReadFiles {
+        /// Files to read.
+        reads: Vec<FileRead>,
+        /// How to process the read results.
+        continuation: Continuation,
+    },
+}
+
+/// Plain data describing the next step of generic API tool execution.
+#[allow(clippy::large_enum_variant)] // Keep prepared requests inline across host adaptation.
+#[derive(Debug)]
+pub enum Continuation {
+    /// Format an HTTP response as the final tool result.
+    FormatApiResponse,
+    /// Inject file contents into a prepared request before HTTP execution.
+    InjectFilesIntoRequest {
+        /// The request awaiting file contents.
+        request: ApiRequest,
+        /// Fields and encodings to use for injection.
+        file_refs: Vec<FileReference>,
+    },
+}
+
+/// The result of a generic I/O effect, supplied by the host.
+pub enum IoResult<'a> {
+    /// An HTTP response.
+    ApiResponse {
+        /// HTTP status code.
+        status: u16,
+        /// Response headers as name/value pairs.
+        headers: &'a [(String, String)],
+        /// Raw response bytes.
+        body: &'a [u8],
+    },
+    /// Results of file read operations.
+    FileReadResults(&'a [FileReadResult]),
+}
+
+/// A file to be read from disk by the I/O layer.
+///
+/// This is a pure data description of the read — no I/O is performed here.
+#[derive(Debug)]
+pub struct FileRead {
+    /// The file path to read.
+    pub path: PathBuf,
+}
+
+/// The outcome of a single file read attempt, reported by the I/O layer.
+pub enum FileReadResult {
+    /// The file was read successfully.
+    Success {
+        /// The path that was read.
+        path: PathBuf,
+        /// The raw file contents.
+        data: Vec<u8>,
+    },
+    /// The file read failed.
+    Error {
+        /// The path that was attempted.
+        path: PathBuf,
+        /// Human-readable error message.
+        message: String,
+    },
+}
+
+/// How file content should be encoded when injected into a request body.
+///
+/// The encoding determines how raw file bytes are converted for the target
+/// field. The appropriate encoding depends on the field type:
+///
+/// - **Text fields** (JSON string values, multipart text parts): use [`TextUtf8`](FileEncoding::TextUtf8)
+/// - **Binary fields** (multipart `format: binary` parts): use [`RawBytes`](FileEncoding::RawBytes)
+/// - **Embedded binary in JSON**: use [`Base64`](FileEncoding::Base64)
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FileEncoding {
+    /// Read the file as UTF-8 text.
+    ///
+    /// For JSON bodies: injected as a JSON string value.
+    /// For multipart bodies: injected as a text form field.
+    ///
+    /// Returns an error if the file is not valid UTF-8.
+    TextUtf8,
+    /// Read the file as raw bytes and base64-encode.
+    ///
+    /// For JSON bodies: injected as a base64-encoded JSON string value.
+    /// For multipart bodies: injected as a text form field containing base64.
+    Base64,
+    /// Read the file as raw bytes (no encoding).
+    ///
+    /// For multipart bodies: injected as a binary form field (`BinaryField`).
+    /// For JSON bodies: returns an error (raw bytes cannot be embedded in JSON).
+    RawBytes,
+}
+
+/// A reference to a file whose content should be injected into a request body field.
+///
+/// Instead of the LLM reading a file into its context and inlining the content,
+/// the server reads the file at execution time. This keeps large file content
+/// out of the LLM's context window.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FileReference {
+    /// File system path to read. Must not be empty or contain `..` segments.
+    pub path: String,
+    /// The body field name to populate with the file content.
+    ///
+    /// For JSON bodies, this is a top-level key in the JSON object.
+    /// For multipart bodies, this is the form field name.
+    pub field: String,
+    /// How to encode the file content for the target field.
+    pub encoding: FileEncoding,
+}
+
+/// Create an [`Effect`] for an expected user-input error.
+///
+/// Returns a successful `CallToolResult` with `is_error: Some(true)`, keeping
+/// the MCP transport clean. Use this for validation failures that the caller
+/// (typically an LLM) can act on — as opposed to protocol-level
+/// `Err(ErrorData)` which signals handler/infrastructure breakage.
+pub fn tool_input_error(message: impl Into<String>) -> Effect {
+    Effect::Done(Ok(CallToolResult::error(vec![ContentBlock::text(
+        message.into(),
+    )])))
+}
+
+/// Validate a file path for use in file I/O effects.
+///
+/// Returns `Ok(PathBuf)` if the path is valid. Returns `Err(message)` if:
+/// - The path is empty or whitespace-only
+/// - The path has no file name component
+/// - The path contains `..` segments (directory traversal)
+pub fn validate_file_path(path: &str) -> Result<PathBuf, String> {
+    let path_buf = PathBuf::from(path);
+    if path.trim().is_empty() || path_buf.file_name().is_none() {
+        return Err(format!("file path must include a file name: {path:?}"));
+    }
+    if path_buf
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(format!(
+            "file path must not contain '..' segments: {path:?}"
+        ));
+    }
+    Ok(path_buf)
+}
+
+const fn http_error_category(status: u16) -> &'static str {
+    match status {
+        400 | 422 => "invalid_request",
+        401 => "authentication",
+        403 => "permission",
+        404 => "not_found",
+        408 => "timeout",
+        409 => "conflict",
+        429 => "rate_limited",
+        502..=504 => "service_unavailable",
+        400..=499 => "client_error",
+        500..=599 => "server_error",
+        _ => "http_error",
+    }
+}
+
+const fn http_error_is_transient(status: u16) -> bool {
+    matches!(status, 408 | 425 | 429 | 500 | 502..=504)
+}
+
+fn retry_after_seconds(headers: &[(String, String)]) -> Option<u64> {
+    const MAX_RETRY_AFTER_SECONDS: u64 = 86_400;
+
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
+        .map(|(_, value)| value.trim_matches([' ', '\t']))
+        .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds <= MAX_RETRY_AFTER_SECONDS)
+}
+
+/// Combine generic HTTP classification with host-approved response details.
+fn sanitized_api_error(
+    status: u16,
+    headers: &[(String, String)],
+    body: &[u8],
+    policy: &Policy,
+) -> String {
+    use std::fmt::Write;
+
+    let transient = http_error_is_transient(status);
+    let mut detail = format!(
+        "API error (HTTP {status}): category={}; transient={transient}",
+        http_error_category(status)
+    );
+
+    (policy.append_error_details)(&mut detail, body);
+    if transient && let Some(seconds) = retry_after_seconds(headers) {
+        let _ = write!(detail, "; retry_after_seconds={seconds}");
+    }
+
+    detail
+}
+
+/// Convert a raw HTTP response into a [`CallToolResult`].
+///
+/// # Arguments
+///
+/// * `status` - HTTP status code
+/// * `headers` - Response headers as `(name, value)` pairs
+/// * `body` - Raw response body bytes
+/// * `policy` - Host policy for interpreting error responses
+///
+/// # Errors
+///
+/// Returns an error if the response cannot be processed.
+pub fn process_api_response(
+    status: u16,
+    headers: &[(String, String)],
+    body: &[u8],
+    policy: &Policy,
+) -> Result<CallToolResult, ErrorData> {
+    let is_success = (200..300).contains(&status);
+    if !is_success {
+        return Ok(CallToolResult::error(vec![ContentBlock::text(
+            sanitized_api_error(status, headers, body, policy),
+        )]));
+    }
+
+    let body_text = match std::str::from_utf8(body) {
+        Ok(text) if response_content_type(headers).is_none_or(content_type_is_textual) => text,
+        _ => {
+            let content = binary_api_response_content(status, headers, body)?;
+            return Ok(CallToolResult::success(vec![content]));
+        }
+    };
+
+    // Try to parse as JSON for nice formatting
+    let content = if let Ok(json_val) = serde_json::from_str::<Value>(body_text) {
+        // LCOV_EXCL_START — serde_json::Value is always serializable as JSON content.
+        ContentBlock::json(&json_val).map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("failed to serialize API response: {e}"),
+                None,
+            )
+        })?
+        // LCOV_EXCL_STOP
+    } else {
+        ContentBlock::text(body_text)
+    };
+
+    Ok(CallToolResult::success(vec![content]))
+}
+
+fn response_content_type(headers: &[(String, String)]) -> Option<&str> {
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+        .map(|(_, value)| value.as_str())
+}
+
+fn content_type_is_textual(content_type: &str) -> bool {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+
+    media_type.starts_with("text/")
+        || media_type == "application/json"
+        || media_type.ends_with("+json")
+        || media_type == "application/xml"
+        || media_type.ends_with("+xml")
+        || media_type == "application/javascript"
+        || media_type == "application/x-www-form-urlencoded"
+}
+
+fn binary_api_response_content(
+    status: u16,
+    headers: &[(String, String)],
+    body: &[u8],
+) -> Result<ContentBlock, ErrorData> {
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut response = serde_json::json!({
+        "status": status,
+        "byteLength": body.len(),
+    });
+
+    if let Some(response) = response.as_object_mut() {
+        response.insert("encoding".to_string(), Value::String("base64".to_string()));
+        response.insert("body".to_string(), Value::String(engine.encode(body)));
+    }
+
+    if let Some(content_type) = response_content_type(headers)
+        && let Some(response) = response.as_object_mut()
+    {
+        response.insert(
+            "contentType".to_string(),
+            Value::String(content_type.to_string()),
+        );
+    }
+
+    ContentBlock::json(&response).map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            format!("failed to serialize binary API response metadata: {e}"),
+            None,
+        )
+    })
+}
+
+/// Resume generic API execution after the host completes an I/O effect.
+///
+/// # Panics
+///
+/// Panics when the result does not match the continuation, indicating an I/O
+/// interpreter programming error.
+#[must_use]
+pub fn resume(continuation: Continuation, result: IoResult<'_>, policy: &Policy) -> Effect {
+    match (continuation, result) {
+        (
+            Continuation::FormatApiResponse,
+            IoResult::ApiResponse {
+                status,
+                headers,
+                body,
+            },
+        ) => Effect::Done(process_api_response(status, headers, body, policy)),
+        (
+            Continuation::InjectFilesIntoRequest { request, file_refs },
+            IoResult::FileReadResults(results),
+        ) => resume_inject_files(request, &file_refs, results, policy),
+        (continuation, result) => unreachable!(
+            "mismatched Continuation and IoResult: continuation={continuation:?}, result kind={}",
+            match result {
+                IoResult::ApiResponse { .. } => "ApiResponse",
+                IoResult::FileReadResults(_) => "FileReadResults",
+            }
+        ),
+    }
+}
+
+/// Inject file content into an API request body after file reads complete.
+///
+/// Extracted from [`resume()`] for readability.
+///
+/// Handles both JSON and multipart request bodies:
+///
+/// - **JSON**: injects content as string values at top-level keys.
+///   [`FileEncoding::TextUtf8`] produces a UTF-8 string, [`FileEncoding::Base64`]
+///   produces a base64-encoded string, and [`FileEncoding::RawBytes`] is an error.
+/// - **Multipart**: [`FileEncoding::RawBytes`] adds a binary form field,
+///   [`FileEncoding::TextUtf8`] adds a text form field, and
+///   [`FileEncoding::Base64`] adds a text form field with base64 content.
+#[allow(clippy::too_many_lines)]
+fn resume_inject_files(
+    mut request: ApiRequest,
+    file_refs: &[FileReference],
+    results: &[FileReadResult],
+    policy: &Policy,
+) -> Effect {
+    // Build a map from path → data for successful reads.
+    let mut reads: HashMap<PathBuf, &[u8]> = HashMap::new();
+    for result in results {
+        match result {
+            FileReadResult::Success { path, data } => {
+                reads.insert(path.clone(), data);
+            }
+            FileReadResult::Error { path, message } => {
+                return tool_input_error(format!(
+                    "failed to read file {}: {message}",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    let Some(body) = request.body.as_mut() else {
+        return tool_input_error("file_refs provided but the endpoint has no request body");
+    };
+
+    match body {
+        RequestBody::Json(value) => {
+            let Some(obj) = value.as_object_mut() else {
+                return tool_input_error("file_refs require the request body to be a JSON object");
+            };
+
+            for file_ref in file_refs {
+                if let Err(e) = inject_into_json_field(obj, file_ref, &reads) {
+                    return tool_input_error(e);
+                }
+            }
+        }
+
+        RequestBody::Multipart(multipart) => {
+            for file_ref in file_refs {
+                if let Err(e) = inject_into_multipart_field(multipart, file_ref, &reads) {
+                    return tool_input_error(e);
+                }
+            }
+        }
+    }
+
+    if let Err(message) = (policy.validate_request)(&request) {
+        return tool_input_error(message);
+    }
+
+    Effect::ApiRequest {
+        request,
+        continuation: Continuation::FormatApiResponse,
+    }
+}
+
+/// Inject a single file reference into a JSON object field.
+///
+/// Returns `Err(message)` on encoding/lookup errors.
+fn inject_into_json_field(
+    obj: &mut Map<String, Value>,
+    file_ref: &FileReference,
+    reads: &HashMap<PathBuf, &[u8]>,
+) -> Result<(), String> {
+    let path = PathBuf::from(&file_ref.path);
+    let Some(data) = reads.get(&path) else {
+        return Err(format!(
+            "no read result for file reference: {}",
+            file_ref.path
+        ));
+    };
+
+    match file_ref.encoding {
+        FileEncoding::TextUtf8 => {
+            let text = std::str::from_utf8(data)
+                .map_err(|e| format!("file {} is not valid UTF-8: {e}", file_ref.path))?;
+            obj.insert(file_ref.field.clone(), Value::String(text.to_owned()));
+        }
+        FileEncoding::Base64 => {
+            let engine = base64::engine::general_purpose::STANDARD;
+            let encoded = engine.encode(data);
+            obj.insert(file_ref.field.clone(), Value::String(encoded));
+        }
+        FileEncoding::RawBytes => {
+            return Err(format!(
+                "file_ref for field {:?} uses raw_bytes encoding, which cannot \
+                 be used with JSON request bodies. Use text_utf8 or base64 instead.",
+                file_ref.field
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Inject a single file reference into a multipart form body.
+///
+/// Returns `Err(message)` on encoding/lookup errors.
+fn inject_into_multipart_field(
+    multipart: &mut MultipartBody,
+    file_ref: &FileReference,
+    reads: &HashMap<PathBuf, &[u8]>,
+) -> Result<(), String> {
+    let path = PathBuf::from(&file_ref.path);
+    let Some(data) = reads.get(&path) else {
+        return Err(format!(
+            "no read result for file reference: {}",
+            file_ref.path
+        ));
+    };
+
+    // Strip any existing entries for this field so file_ref wins
+    // (matches JSON path semantics where Map::insert replaces).
+    multipart
+        .text_fields
+        .retain(|(name, _)| name != &file_ref.field);
+    multipart
+        .binary_fields
+        .retain(|f| f.field_name != file_ref.field);
+
+    match file_ref.encoding {
+        FileEncoding::RawBytes => {
+            multipart.binary_fields.push(BinaryField {
+                field_name: file_ref.field.clone(),
+                data: data.to_vec(),
+                content_type: None,
+            });
+        }
+        FileEncoding::TextUtf8 => {
+            let text = std::str::from_utf8(data)
+                .map_err(|e| format!("file {} is not valid UTF-8: {e}", file_ref.path))?;
+            multipart
+                .text_fields
+                .push((file_ref.field.clone(), text.to_owned()));
+        }
+        FileEncoding::Base64 => {
+            let engine = base64::engine::general_purpose::STANDARD;
+            let encoded = engine.encode(data);
+            multipart
+                .text_fields
+                .push((file_ref.field.clone(), encoded));
+        }
+    }
+    Ok(())
+}

--- a/crates/onshape-mcp-core/src/tools/onshape.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape.rs
@@ -1,15 +1,57 @@
 //! Onshape request validation and diagnostic interpretation for MCP tools.
 //!
-//! These helpers operate only on data. The parent dispatcher supplies validation
-//! to the `api` handlers and applies policy when resuming file reads or formatting
-//! HTTP errors.
+//! This adapter supplies policy to generic API execution and translates its
+//! effects into the public Onshape dispatcher types. All helpers operate on data.
 
 use std::collections::{HashMap, HashSet};
 
 use onshape_openapi::request::{ApiRequest, RequestBody};
 use serde_json::{Map, Value};
 
-use super::FileReference;
+use super::{Continuation, FileReference, ToolEffect, api};
+
+/// Onshape policy for request preparation, file injection, and API errors.
+pub const API_POLICY: api::Policy = api::Policy {
+    validate_body: validate_call_body,
+    validate_request: validate_injected_request,
+    append_error_details: append_api_error_details,
+};
+
+/// Translate a generic effect into the existing dispatcher representation.
+pub fn adapt_api_effect(effect: api::Effect) -> ToolEffect {
+    match effect {
+        api::Effect::Done(result) => ToolEffect::Done(result),
+        api::Effect::ApiRequest {
+            request,
+            continuation,
+        } => ToolEffect::ApiRequest {
+            request,
+            continuation: adapt_api_continuation(continuation),
+        },
+        api::Effect::ReadFiles {
+            reads,
+            continuation,
+        } => ToolEffect::ReadFiles {
+            reads,
+            continuation: adapt_api_continuation(continuation),
+        },
+    }
+}
+
+/// Translate generic continuation data without retaining policy callbacks.
+fn adapt_api_continuation(continuation: api::Continuation) -> Continuation {
+    match continuation {
+        api::Continuation::FormatApiResponse => Continuation::FormatApiResponse,
+        api::Continuation::InjectFilesIntoRequest { request, file_refs } => {
+            Continuation::InjectFilesIntoRequest { request, file_refs }
+        }
+    }
+}
+
+/// Resume generic execution using Onshape policy and translate its next effect.
+pub fn resume_api(continuation: api::Continuation, result: api::IoResult<'_>) -> ToolEffect {
+    adapt_api_effect(api::resume(continuation, result, &API_POLICY))
+}
 
 /// Apply Onshape endpoint validation before request construction and file reads.
 ///


### PR DESCRIPTION
Generic API handlers still relied on the Onshape dispatcher for continuations, file injection, and response formatting. Introduce a private `api::execution` module with its own effects, continuations, I/O results, and resumption logic. It owns the generic file types, path checks, JSON/multipart injection, HTTP classification, and text/binary response formatting.

The Onshape adapter supplies synchronous policy for body validation, validation after file injection, and allowlisted error details. It translates generic effects and continuations into the existing public dispatcher types. Policy callbacks stay outside continuations, and the public file type paths are preserved through re-exports.

Tool metadata, validation order, response shapes, retry guidance, and the I/O dispatch interface are preserved. All existing dispatcher tests remain unchanged. New tests exercise a generic file-read → request → response flow, host rejection after injection, host error details alongside retry guidance, and mismatched continuation/result handling.

Validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` — 646 tests passed, including doctests.
