### PR TITLE
Make generic API tool metadata host-configurable

### DIFF
--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -42,7 +42,10 @@ use onshape_openapi::request::ApiRequest;
 #[cfg(test)]
 use onshape_openapi::request::{MultipartBody, RequestBody};
 
-pub use api::{FileEncoding, FileRead, FileReadResult, FileReference};
+pub use api::{
+    ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput, FileEncoding, FileRead,
+    FileReadResult, FileReference,
+};
 use api::{parse_arguments, validate_file_path};
 
 use crate::config::ResolvedAuth;
@@ -518,19 +521,19 @@ fn resume_screenshot_response(
 /// Returns all available tools.
 #[must_use]
 pub fn list_tools() -> Vec<Tool> {
-    vec![
+    let mut tools = vec![
         tool_get_started_def(),
         tool_auth_status_def(),
         tool_auth_login_def(),
-        tool_api_search_def(),
-        tool_api_explain_def(),
-        tool_api_call_def(),
-        tool_api_schema_def(),
+    ];
+    tools.extend(onshape::api_tools().list());
+    tools.extend([
         tool_list_resources_def(),
         tool_read_resource_def(),
         tool_screenshot_def(),
         tool_error_lookup_def(),
-    ]
+    ]);
+    tools
 }
 
 /// Dispatches a tool call by name.
@@ -552,38 +555,23 @@ pub fn call_tool(
     validation: &ValidationState,
     spec: Option<&OpenApiSpec>,
 ) -> ToolEffect {
+    if let Some(kind) = onshape::api_tools().resolve(name) {
+        let spec = match require_spec(spec) {
+            Ok(spec) => spec,
+            Err(error) => return ToolEffect::Done(Err(error)),
+        };
+        return onshape::adapt_api_effect(api::dispatch(
+            kind,
+            arguments,
+            spec,
+            &onshape::API_POLICY,
+        ));
+    }
+
     match name {
         "onshape_mcp_get_started" => ToolEffect::Done(Ok(call_get_started())),
         "onshape_auth_status" => call_auth_status(arguments, resolved_auth, validation, spec),
         "onshape_auth_login" => call_auth_login(arguments),
-        "onshape_api_search" => {
-            let spec = match require_spec(spec) {
-                Ok(s) => s,
-                Err(e) => return ToolEffect::Done(Err(e)),
-            };
-            ToolEffect::Done(api::search(arguments, spec))
-        }
-        "onshape_api_explain" => {
-            let spec = match require_spec(spec) {
-                Ok(s) => s,
-                Err(e) => return ToolEffect::Done(Err(e)),
-            };
-            ToolEffect::Done(api::explain(arguments, spec))
-        }
-        "onshape_api_call" => {
-            let spec = match require_spec(spec) {
-                Ok(s) => s,
-                Err(e) => return ToolEffect::Done(Err(e)),
-            };
-            onshape::adapt_api_effect(api::call(arguments, spec, &onshape::API_POLICY))
-        }
-        "onshape_api_schema" => {
-            let spec = match require_spec(spec) {
-                Ok(s) => s,
-                Err(e) => return ToolEffect::Done(Err(e)),
-            };
-            ToolEffect::Done(api::schema(arguments, spec))
-        }
         "onshape_list_resources" => ToolEffect::Done(Ok(call_list_resources())),
         "onshape_read_resource" => ToolEffect::Done(Ok(call_read_resource(arguments))),
         "onshape_error_lookup" => ToolEffect::Done(Ok(call_error_lookup(arguments))),
@@ -620,60 +608,6 @@ pub struct AuthStatusInput {
     pub validate: Option<bool>,
 }
 
-/// Input schema for `onshape_api_search`.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct ApiSearchInput {
-    /// Free-text search query. Matches against endpoint names, paths,
-    /// descriptions, and tags. Leave empty to list all endpoints.
-    pub query: String,
-    /// Filter by HTTP method (e.g., "GET", "POST", "DELETE").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<String>,
-    /// Filter by tag name (e.g., "Document", "Assembly", "`PartStudio`").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tag: Option<String>,
-}
-
-/// Input schema for `onshape_api_explain`.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ApiExplainInput {
-    /// The operation ID of the endpoint to explain (from search results).
-    pub endpoint: String,
-}
-
-/// Input schema for `onshape_api_call`.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ApiCallInput {
-    /// The operation ID of the endpoint to call.
-    pub endpoint: String,
-    /// Path parameters (e.g., `{"did": "abc123", "wid": "def456"}`).
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub path_params: HashMap<String, String>,
-    /// Query parameters (e.g., `{"q": "robot arm", "limit": "10"}`).
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub query_params: HashMap<String, String>,
-    /// Header parameters (e.g., `{"Accept": "application/octet-stream"}`).
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub header_params: HashMap<String, String>,
-    /// JSON value for the request body (for POST/PUT/PATCH endpoints).
-    /// Legacy serialized JSON strings are also accepted for compatibility. Use
-    /// `onshape_api_explain` to see the expected schema for each endpoint.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<Value>,
-    /// File references for fields whose content should be read from disk.
-    ///
-    /// Each reference specifies a file path, a body field name, and an encoding.
-    /// The server reads the files and injects their content into the request body
-    /// after building the request. Fields listed here should be omitted from `body`.
-    ///
-    /// Example: to upload a file via `uploadFileCreateElement`, pass the metadata
-    /// fields in `body` and use `file_refs` for the binary content:
-    /// `body: {"formatName": "PARASOLID"}`,
-    /// `file_refs: [{"path": "/tmp/part.x_t", "field": "file", "encoding": "raw_bytes"}]`
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub file_refs: Vec<FileReference>,
-}
-
 /// Input schema for `onshape_auth_login`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct AuthLoginInput {
@@ -691,16 +625,6 @@ pub struct AuthLoginInput {
     /// OAuth 2.0 client secret. Required for direct mode.
     #[serde(default)]
     pub client_secret: Option<String>,
-}
-
-/// Input schema for `onshape_api_schema`.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ApiSchemaInput {
-    /// The schema name to look up (e.g., `"BTMParameterEnum-145"` or
-    /// `"BTFeatureDefinitionCall-1406"`). Use schema names from
-    /// `x-bttype-options` annotations in `onshape_api_explain` results,
-    /// or from the `subtypes` field in previous `onshape_api_schema` results.
-    pub schema: String,
 }
 
 /// Input schema for `onshape_read_resource`.
@@ -867,69 +791,6 @@ fn tool_auth_login_def() -> Tool {
 }
 
 #[allow(clippy::expect_used)]
-fn tool_api_search_def() -> Tool {
-    let schema = schemars::schema_for!(ApiSearchInput);
-    let input_schema: Value = serde_json::to_value(schema)
-        .expect("ApiSearchInput schema serialization should never fail");
-    let input_schema = input_schema
-        .as_object()
-        .cloned()
-        .expect("Schema should be a JSON object");
-
-    Tool::new(
-        "onshape_api_search",
-        "Find Onshape API endpoints by keyword or filter. Returns brief summaries \
-         (endpoint ID, method, path template, one-line description). Use this to \
-         discover available endpoints before calling onshape_api_explain for details.",
-        Arc::new(input_schema),
-    )
-    .annotate(ToolAnnotations::new().read_only(true).destructive(false))
-}
-
-#[allow(clippy::expect_used)]
-fn tool_api_explain_def() -> Tool {
-    let schema = schemars::schema_for!(ApiExplainInput);
-    let input_schema: Value = serde_json::to_value(schema)
-        .expect("ApiExplainInput schema serialization should never fail");
-    let input_schema = input_schema
-        .as_object()
-        .cloned()
-        .expect("Schema should be a JSON object");
-
-    Tool::new(
-        "onshape_api_explain",
-        "Get full details for a specific Onshape API endpoint. Returns parameter schemas, \
-         types, required/optional flags, request/response schemas. Use the endpoint's \
-         operationId from onshape_api_search results.",
-        Arc::new(input_schema),
-    )
-    .annotate(ToolAnnotations::new().read_only(true).destructive(false))
-}
-
-#[allow(clippy::expect_used)]
-fn tool_api_call_def() -> Tool {
-    let schema = schemars::schema_for!(ApiCallInput);
-    let input_schema: Value =
-        serde_json::to_value(schema).expect("ApiCallInput schema serialization should never fail");
-    let input_schema = input_schema
-        .as_object()
-        .cloned()
-        .expect("Schema should be a JSON object");
-
-    Tool::new(
-        "onshape_api_call",
-        "Invoke an Onshape API endpoint. Provide the operationId and structured parameters \
-         (path_params, query_params, body). Path parameters are named fields (e.g., \
-         {\"did\": \"abc123\"}), not baked into a URL string. For endpoints that accept \
-         file content (e.g., file uploads), use `file_refs` to reference local files \
-         instead of inlining content in the body — the server reads them directly. \
-         Returns the API response.",
-        Arc::new(input_schema),
-    )
-    .annotate(ToolAnnotations::new().read_only(false).destructive(true))
-}
-
-#[allow(clippy::expect_used)]
 fn tool_list_resources_def() -> Tool {
     let schema = schemars::schema_for!(EmptyInput);
     let input_schema: Value =
@@ -948,27 +809,6 @@ fn tool_list_resources_def() -> Tool {
          something — the answer may already be documented here. Returns URIs, \
          titles, and descriptions. Use onshape_read_resource to read a specific \
          resource by URI.",
-        Arc::new(input_schema),
-    )
-    .annotate(ToolAnnotations::new().read_only(true).destructive(false))
-}
-
-#[allow(clippy::expect_used)]
-fn tool_api_schema_def() -> Tool {
-    let schema = schemars::schema_for!(ApiSchemaInput);
-    let input_schema: Value = serde_json::to_value(schema)
-        .expect("ApiSchemaInput schema serialization should never fail");
-    let input_schema = input_schema
-        .as_object()
-        .cloned()
-        .expect("Schema should be a JSON object");
-
-    Tool::new(
-        "onshape_api_schema",
-        "Look up an Onshape API schema by name. Returns the schema's properties \
-         (merged with inherited parent properties), discriminator subtypes if \
-         polymorphic, and parent type. Use schema names from x-bttype-options \
-         annotations in onshape_api_explain results to drill into specific types.",
         Arc::new(input_schema),
     )
     .annotate(ToolAnnotations::new().read_only(true).destructive(false))
@@ -1706,7 +1546,10 @@ mod tests {
 
     #[test]
     fn api_call_schema_allows_direct_json_values() {
-        let tool = tool_api_call_def();
+        let tool = list_tools()
+            .into_iter()
+            .find(|tool| tool.name == "onshape_api_call")
+            .expect("API call tool should be advertised");
         let body_schema = &tool.input_schema["properties"]["body"];
         assert!(
             body_schema.as_bool() == Some(true)
@@ -1759,6 +1602,22 @@ mod tests {
     fn list_tools_has_eleven_tools() {
         let tools = list_tools();
         assert_eq!(tools.len(), 11);
+    }
+
+    #[test]
+    fn onshape_api_metadata_matches_published_contract() {
+        // Captured from the published definitions before host configuration was introduced.
+        let expected: Value =
+            serde_json::from_str(include_str!("../tests/fixtures/onshape-api-tools.json"))
+                .expect("valid metadata fixture");
+        let tools: Vec<_> = list_tools()
+            .into_iter()
+            .filter(|tool| tool.name.starts_with("onshape_api_"))
+            .collect();
+        assert_eq!(
+            serde_json::to_value(tools).expect("tool metadata"),
+            expected
+        );
     }
 
     // --- auth_status tests ---

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -1,10 +1,15 @@
 //! Pure `OpenAPI` tool handlers.
 //!
 //! The `execution` module owns generic effects, file injection, and response
-//! formatting. The host supplies validation and diagnostic policy. Tool metadata
-//! and the four tool input schemas are owned by the parent module.
+//! formatting. Generic input types and host-configured tool metadata live here
+//! too. The host supplies presentation, validation, and diagnostic policy.
 
 mod execution;
+mod input;
+mod metadata;
+
+pub use input::{ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput};
+pub(super) use metadata::{ToolDefinition, ToolKind, ToolSet};
 
 use execution::tool_input_error;
 pub(super) use execution::{
@@ -24,7 +29,20 @@ use rmcp::{
 };
 use serde_json::{Map, Value};
 
-use super::{ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput};
+/// Dispatch a resolved API tool operation using the supplied host policy.
+pub(super) fn dispatch(
+    kind: ToolKind,
+    arguments: Option<&Map<String, Value>>,
+    spec: &OpenApiSpec,
+    policy: &Policy,
+) -> Effect {
+    match kind {
+        ToolKind::Search => Effect::Done(search(arguments, spec)),
+        ToolKind::Explain => Effect::Done(explain(arguments, spec)),
+        ToolKind::Call => call(arguments, spec, policy),
+        ToolKind::Schema => Effect::Done(schema(arguments, spec)),
+    }
+}
 
 pub(super) fn search(
     arguments: Option<&Map<String, Value>>,
@@ -273,6 +291,190 @@ mod tests {
         }
     }
 
+    const DOCUMENT_TOOL_NAMES: [&str; 4] = [
+        "catalog_find",
+        "endpoint_details",
+        "run_request",
+        "type_details",
+    ];
+
+    fn document_tool_definitions(names: [&str; 4]) -> [ToolDefinition<'_>; 4] {
+        [
+            ToolDefinition {
+                kind: ToolKind::Search,
+                name: names[0],
+                description: "Find document endpoints, then use endpoint_details.",
+                input_description: Some("Document catalog search."),
+                field_descriptions: &[("query", "Words to find in the document catalog.")],
+            },
+            ToolDefinition {
+                kind: ToolKind::Explain,
+                name: names[1],
+                description: "Explain an endpoint found with catalog_find.",
+                input_description: None,
+                field_descriptions: &[],
+            },
+            ToolDefinition {
+                kind: ToolKind::Call,
+                name: names[2],
+                description: "Invoke a document endpoint.",
+                input_description: None,
+                field_descriptions: &[(
+                    "body",
+                    "Use endpoint_details to inspect the request schema.",
+                )],
+            },
+            ToolDefinition {
+                kind: ToolKind::Schema,
+                name: names[3],
+                description: "Look up a document schema.",
+                input_description: None,
+                field_descriptions: &[],
+            },
+        ]
+    }
+
+    #[test]
+    fn configured_metadata_owns_names_and_preserves_input_contracts() {
+        let tools = {
+            let names = DOCUMENT_TOOL_NAMES.map(str::to_owned);
+            let mut definitions = document_tool_definitions(names.each_ref().map(String::as_str));
+            definitions.swap(0, 2);
+            ToolSet::new(&definitions).expect("valid document tool definitions")
+        };
+        let advertised = tools.list();
+        let names: Vec<_> = advertised.iter().map(|tool| tool.name.as_ref()).collect();
+        assert_eq!(
+            names,
+            [
+                "run_request",
+                "endpoint_details",
+                "catalog_find",
+                "type_details"
+            ]
+        );
+        let metadata = serde_json::to_value(advertised).expect("serializable tool metadata");
+        assert!(!metadata.to_string().to_lowercase().contains("onshape"));
+        assert_eq!(
+            metadata[2]["description"],
+            "Find document endpoints, then use endpoint_details."
+        );
+        assert_eq!(
+            metadata[2]["inputSchema"]["description"],
+            "Document catalog search."
+        );
+        assert_eq!(
+            metadata[2]["inputSchema"]["properties"]["query"]["description"],
+            "Words to find in the document catalog."
+        );
+        assert_eq!(
+            metadata[2]["inputSchema"]["properties"]["query"]["type"],
+            "string"
+        );
+        assert_eq!(metadata[2]["inputSchema"]["required"], json!(["query"]));
+        assert_eq!(metadata[0]["inputSchema"]["required"], json!(["endpoint"]));
+        assert_eq!(
+            metadata[0]["inputSchema"]["properties"]["body"]["description"],
+            "Use endpoint_details to inspect the request schema."
+        );
+        for (index, tool) in metadata.as_array().expect("tool list").iter().enumerate() {
+            assert_eq!(tool["annotations"]["readOnlyHint"], index != 0);
+            assert_eq!(tool["annotations"]["destructiveHint"], index == 0);
+        }
+        assert_eq!(tools.resolve("onshape_api_call"), None);
+        assert_eq!(tools.resolve("unknown_tool"), None);
+    }
+
+    #[test]
+    fn configured_names_dispatch_all_four_operations() {
+        let tools = ToolSet::new(&document_tool_definitions(DOCUMENT_TOOL_NAMES))
+            .expect("valid document tool definitions");
+        let spec = document_store_spec();
+        let host_policy = policy(|_, _, _| Ok(()));
+        for (name, arguments, expected_field, expected_value) in [
+            (
+                "catalog_find",
+                json!({ "query": "createDocument" }),
+                "/0/operation_id",
+                "createDocument",
+            ),
+            (
+                "endpoint_details",
+                json!({ "endpoint": "createDocument" }),
+                "/path",
+                "/documents",
+            ),
+            (
+                "type_details",
+                json!({ "schema": "Document" }),
+                "/name",
+                "Document",
+            ),
+        ] {
+            let kind = tools.resolve(name).expect("configured tool name");
+            let Effect::Done(Ok(result)) =
+                dispatch(kind, arguments.as_object(), &spec, &host_policy)
+            else {
+                panic!("catalog tools should complete without I/O");
+            };
+            assert_ne!(result.is_error, Some(true));
+            let text = &result.content[0].as_text().expect("JSON text content").text;
+            let value: Value = serde_json::from_str(text).expect("valid JSON");
+            assert_eq!(value.pointer(expected_field), Some(&json!(expected_value)));
+        }
+
+        let arguments = json!({ "endpoint": "createDocument", "body": { "title": "Example" } });
+        let kind = tools.resolve("run_request").expect("configured call tool");
+        let Effect::ApiRequest { request, .. } =
+            dispatch(kind, arguments.as_object(), &spec, &host_policy)
+        else {
+            panic!("the configured call tool should prepare an API request");
+        };
+        assert_eq!(request.method, http::Method::POST);
+        assert_eq!(request.path, "/documents");
+        assert_eq!(
+            request.body.as_ref().and_then(RequestBody::as_json),
+            Some(&json!({ "title": "Example" }))
+        );
+    }
+
+    #[test]
+    fn tool_configuration_rejects_ambiguous_or_blank_names() {
+        let definitions = document_tool_definitions(DOCUMENT_TOOL_NAMES);
+        let mut duplicate_name = definitions;
+        duplicate_name[1].name = duplicate_name[0].name;
+        assert_eq!(
+            ToolSet::new(&duplicate_name).expect_err("duplicate name"),
+            "duplicate API tool name: catalog_find"
+        );
+
+        let mut duplicate_kind = definitions;
+        duplicate_kind[1].kind = ToolKind::Search;
+        assert_eq!(
+            ToolSet::new(&duplicate_kind).expect_err("duplicate operation leaves one missing"),
+            "duplicate API tool kind: Search"
+        );
+
+        for name in ["", " \t\n"] {
+            let mut blank_name = definitions;
+            blank_name[1].name = name;
+            assert_eq!(
+                ToolSet::new(&blank_name).expect_err("blank name"),
+                "API tool name must not be blank"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_configuration_rejects_unknown_description_fields() {
+        let mut definitions = document_tool_definitions(DOCUMENT_TOOL_NAMES);
+        definitions[0].field_descriptions = &[("missing_field", "Unknown field name.")];
+        assert_eq!(
+            ToolSet::new(&definitions).expect_err("invalid description override"),
+            "invalid API input description field \"missing_field\" for Search"
+        );
+    }
+
     fn file_upload_arguments() -> Value {
         json!({
             "endpoint": "createDocument",
@@ -452,6 +654,14 @@ mod tests {
                 "openapi": "3.0.1",
                 "info": { "title": "Document Store", "version": "1.0" },
                 "servers": [{ "url": "https://documents.example.com" }],
+                "components": {
+                    "schemas": {
+                        "Document": {
+                            "type": "object",
+                            "properties": { "title": { "type": "string" } }
+                        }
+                    }
+                },
                 "paths": {
                     "/documents": {
                         "post": {

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -466,6 +466,54 @@ mod tests {
     }
 
     #[test]
+    fn tool_configuration_rejects_names_outside_mcp_guidance() {
+        let too_long = "a".repeat(129);
+        for name in [
+            " tool",
+            "tool ",
+            "two words",
+            "tool\tname",
+            "tool\nname",
+            "tool/name",
+            "tool,name",
+            "tool:name",
+            "café",
+            "\0name",
+            &too_long,
+        ] {
+            let mut definitions = document_tool_definitions(DOCUMENT_TOOL_NAMES);
+            definitions[0].name = name;
+            assert_eq!(
+                ToolSet::new(&definitions).expect_err("invalid tool name"),
+                format!(
+                    "invalid API tool name {name:?}: expected 1-128 ASCII letters, digits, underscores, hyphens, or periods"
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn tool_configuration_accepts_mcp_name_boundaries_and_distinct_case() {
+        let longest = "a".repeat(128);
+        let names = ["a", "A", "Admin.tools-v2_0", &longest];
+        let tools = ToolSet::new(&document_tool_definitions(names))
+            .expect("valid names at the length boundaries and with all allowed character classes");
+        for ((name, kind), advertised) in names
+            .into_iter()
+            .zip([
+                ToolKind::Search,
+                ToolKind::Explain,
+                ToolKind::Call,
+                ToolKind::Schema,
+            ])
+            .zip(tools.list())
+        {
+            assert_eq!(advertised.name, name);
+            assert_eq!(tools.resolve(name), Some(kind));
+        }
+    }
+
+    #[test]
     fn tool_configuration_rejects_unknown_description_fields() {
         let mut definitions = document_tool_definitions(DOCUMENT_TOOL_NAMES);
         definitions[0].field_descriptions = &[("missing_field", "Unknown field name.")];

--- a/crates/onshape-mcp-core/src/tools/api/input.rs
+++ b/crates/onshape-mcp-core/src/tools/api/input.rs
@@ -1,0 +1,66 @@
+//! Generic input types for API tools; hosts configure the advertised wording.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::FileReference;
+
+/// Input schema for the API search tool.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ApiSearchInput {
+    /// Free-text search query. Matches against endpoint names, paths,
+    /// descriptions, and tags. Leave empty to list all endpoints.
+    pub query: String,
+    /// Filter by HTTP method (e.g., "GET", "POST", "DELETE").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// Filter by tag name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+}
+
+/// Input schema for the API explain tool.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ApiExplainInput {
+    /// The operation ID of the endpoint to explain (from search results).
+    pub endpoint: String,
+}
+
+/// Input schema for the API call tool.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ApiCallInput {
+    /// The operation ID of the endpoint to call.
+    pub endpoint: String,
+    /// Path parameters keyed by the names in the endpoint path template.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub path_params: HashMap<String, String>,
+    /// Query parameters keyed by parameter name.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub query_params: HashMap<String, String>,
+    /// Header parameters (e.g., `{"Accept": "application/octet-stream"}`).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub header_params: HashMap<String, String>,
+    /// JSON value for the request body (for POST/PUT/PATCH endpoints).
+    /// Legacy serialized JSON strings are also accepted for compatibility.
+    /// Explain the endpoint to see its expected request schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<Value>,
+    /// File references for fields whose content should be read from disk.
+    ///
+    /// Each reference specifies a file path, a body field name, and an encoding.
+    /// The server reads the files and injects their content into the request body
+    /// after building the request. Fields listed here should be omitted from `body`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_refs: Vec<FileReference>,
+}
+
+/// Input schema for the API schema tool.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ApiSchemaInput {
+    /// The component schema name to look up, taken from an endpoint explanation
+    /// or a previous schema lookup.
+    pub schema: String,
+}

--- a/crates/onshape-mcp-core/src/tools/api/metadata.rs
+++ b/crates/onshape-mcp-core/src/tools/api/metadata.rs
@@ -26,7 +26,7 @@ pub enum ToolKind {
 pub struct ToolDefinition<'a> {
     /// The operation this name invokes.
     pub kind: ToolKind,
-    /// The advertised and accepted tool name.
+    /// The advertised and accepted tool name: 1-128 ASCII letters, digits, `_`, `-`, or `.`.
     pub name: &'a str,
     /// The advertised tool description, including any cross-tool guidance.
     pub description: &'a str,
@@ -47,8 +47,8 @@ impl ToolSet {
     ///
     /// # Errors
     ///
-    /// Rejects blank or duplicate names, duplicate operations, and description
-    /// overrides that do not name an object-valued input property schema.
+    /// Rejects names outside the MCP naming guidance, duplicate names or operations,
+    /// and description overrides that do not name an object-valued input property schema.
     pub fn new(definitions: &[ToolDefinition<'_>; 4]) -> Result<Self, String> {
         let mut names = HashSet::new();
         let mut kinds = HashSet::new();
@@ -56,6 +56,17 @@ impl ToolSet {
         for definition in definitions {
             if definition.name.trim().is_empty() {
                 return Err("API tool name must not be blank".into());
+            }
+            if definition.name.len() > 128
+                || !definition
+                    .name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+            {
+                return Err(format!(
+                    "invalid API tool name {:?}: expected 1-128 ASCII letters, digits, underscores, hyphens, or periods",
+                    definition.name
+                ));
             }
             if !names.insert(definition.name) {
                 return Err(format!("duplicate API tool name: {}", definition.name));

--- a/crates/onshape-mcp-core/src/tools/api/metadata.rs
+++ b/crates/onshape-mcp-core/src/tools/api/metadata.rs
@@ -1,0 +1,130 @@
+//! Host-configured presentation and name resolution for the four API tools.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use rmcp::model::{Tool, ToolAnnotations};
+use serde_json::Value;
+
+use super::{ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput};
+
+/// The operation behind a configured tool name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ToolKind {
+    /// Search the specification for endpoints.
+    Search,
+    /// Explain one endpoint.
+    Explain,
+    /// Prepare an API request for execution.
+    Call,
+    /// Look up a component schema.
+    Schema,
+}
+
+/// Host wording for one tool, separate from its input structure and behavior.
+#[derive(Clone, Copy)]
+pub struct ToolDefinition<'a> {
+    /// The operation this name invokes.
+    pub kind: ToolKind,
+    /// The advertised and accepted tool name.
+    pub name: &'a str,
+    /// The advertised tool description, including any cross-tool guidance.
+    pub description: &'a str,
+    /// Optional replacement for the input schema's top-level description.
+    pub input_description: Option<&'a str>,
+    /// Description overrides for named top-level input properties.
+    pub field_descriptions: &'a [(&'a str, &'a str)],
+}
+
+/// Validated tool definitions used for both discovery and dispatch.
+#[derive(Debug)]
+pub struct ToolSet {
+    entries: Vec<(ToolKind, Tool)>,
+}
+
+impl ToolSet {
+    /// Build one definition for each API operation in the supplied display order.
+    ///
+    /// # Errors
+    ///
+    /// Rejects blank or duplicate names, duplicate operations, and description
+    /// overrides that do not name an object-valued input property schema.
+    pub fn new(definitions: &[ToolDefinition<'_>; 4]) -> Result<Self, String> {
+        let mut names = HashSet::new();
+        let mut kinds = HashSet::new();
+        let mut entries = Vec::with_capacity(definitions.len());
+        for definition in definitions {
+            if definition.name.trim().is_empty() {
+                return Err("API tool name must not be blank".into());
+            }
+            if !names.insert(definition.name) {
+                return Err(format!("duplicate API tool name: {}", definition.name));
+            }
+            if !kinds.insert(definition.kind) {
+                return Err(format!("duplicate API tool kind: {:?}", definition.kind));
+            }
+            entries.push((definition.kind, definition.build()?));
+        }
+        Ok(Self { entries })
+    }
+
+    /// Return the advertised tools in their configured order.
+    pub fn list(&self) -> Vec<Tool> {
+        self.entries.iter().map(|(_, tool)| tool.clone()).collect()
+    }
+
+    /// Resolve an advertised name to its operation, leaving other names to the host.
+    pub fn resolve(&self, name: &str) -> Option<ToolKind> {
+        self.entries
+            .iter()
+            .find_map(|(kind, tool)| (tool.name == name).then_some(*kind))
+    }
+}
+
+impl ToolDefinition<'_> {
+    /// Apply documentation overrides while retaining the generated input structure.
+    #[allow(clippy::expect_used)] // These concrete input types always produce object schemas.
+    fn build(self) -> Result<Tool, String> {
+        let schema = match self.kind {
+            ToolKind::Search => schemars::schema_for!(ApiSearchInput),
+            ToolKind::Explain => schemars::schema_for!(ApiExplainInput),
+            ToolKind::Call => schemars::schema_for!(ApiCallInput),
+            ToolKind::Schema => schemars::schema_for!(ApiSchemaInput),
+        };
+        let mut input_schema = serde_json::to_value(schema)
+            .expect("API input schema serialization should never fail")
+            .as_object()
+            .cloned()
+            .expect("API input schema should be an object");
+        if let Some(description) = self.input_description {
+            input_schema.insert("description".into(), Value::String(description.into()));
+        }
+        let properties = input_schema
+            .get_mut("properties")
+            .and_then(Value::as_object_mut)
+            .expect("API input schema should define properties");
+        for &(name, description) in self.field_descriptions {
+            let property = properties
+                .get_mut(name)
+                .and_then(Value::as_object_mut)
+                .ok_or_else(|| {
+                    format!(
+                        "invalid API input description field {name:?} for {:?}",
+                        self.kind
+                    )
+                })?;
+            property.insert("description".into(), Value::String(description.into()));
+        }
+        let invokes_api = self.kind == ToolKind::Call;
+        Ok(Tool::new(
+            self.name.to_owned(),
+            self.description.to_owned(),
+            Arc::new(input_schema),
+        )
+        .annotate(
+            ToolAnnotations::new()
+                .read_only(!invokes_api)
+                .destructive(invokes_api),
+        ))
+    }
+}

--- a/crates/onshape-mcp-core/src/tools/onshape.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape.rs
@@ -3,6 +3,10 @@
 //! This adapter supplies policy to generic API execution and translates its
 //! effects into the public Onshape dispatcher types. All helpers operate on data.
 
+mod metadata;
+
+pub use metadata::api_tools;
+
 use std::collections::{HashMap, HashSet};
 
 use onshape_openapi::request::{ApiRequest, RequestBody};

--- a/crates/onshape-mcp-core/src/tools/onshape/metadata.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape/metadata.rs
@@ -1,0 +1,106 @@
+//! Onshape names and guidance for the generic API tools.
+
+use std::sync::OnceLock;
+
+use super::api::{ToolDefinition, ToolKind, ToolSet};
+
+/// The shared source of Onshape API tool discovery metadata and dispatch names.
+#[allow(clippy::expect_used)] // Static host configuration is verified by the metadata regression test.
+pub fn api_tools() -> &'static ToolSet {
+    static TOOLS: OnceLock<ToolSet> = OnceLock::new();
+    TOOLS.get_or_init(|| {
+        ToolSet::new(&[
+            ToolDefinition {
+                kind: ToolKind::Search,
+                name: "onshape_api_search",
+                description: concat!(
+                    "Find Onshape API endpoints by keyword or filter. Returns brief summaries (endpoint ID, ",
+                    "method, path template, one-line description). Use this to discover available endpoints ",
+                    "before calling onshape_api_explain for details.",
+                ),
+                input_description: Some("Input schema for `onshape_api_search`."),
+                field_descriptions: &[(
+                    "tag",
+                    "Filter by tag name (e.g., \"Document\", \"Assembly\", \"`PartStudio`\").",
+                )],
+            },
+            ToolDefinition {
+                kind: ToolKind::Explain,
+                name: "onshape_api_explain",
+                description: concat!(
+                    "Get full details for a specific Onshape API endpoint. Returns parameter schemas, types, ",
+                    "required/optional flags, request/response schemas. Use the endpoint's operationId from ",
+                    "onshape_api_search results.",
+                ),
+                input_description: Some("Input schema for `onshape_api_explain`."),
+                field_descriptions: &[],
+            },
+            ToolDefinition {
+                kind: ToolKind::Call,
+                name: "onshape_api_call",
+                description: concat!(
+                    "Invoke an Onshape API endpoint. Provide the operationId and structured parameters ",
+                    "(path_params, query_params, body). Path parameters are named fields (e.g., {\"did\": ",
+                    "\"abc123\"}), not baked into a URL string. For endpoints that accept file content (e.g., ",
+                    "file uploads), use `file_refs` to reference local files instead of inlining content in ",
+                    "the body — the server reads them directly. Returns the API response.",
+                ),
+                input_description: Some("Input schema for `onshape_api_call`."),
+                field_descriptions: &[
+                    (
+                        "path_params",
+                        "Path parameters (e.g., `{\"did\": \"abc123\", \"wid\": \"def456\"}`).",
+                    ),
+                    (
+                        "query_params",
+                        "Query parameters (e.g., `{\"q\": \"robot arm\", \"limit\": \"10\"}`).",
+                    ),
+                    (
+                        "body",
+                        concat!(
+                            "JSON value for the request body (for POST/PUT/PATCH endpoints).\n",
+                            "Legacy serialized JSON strings are also accepted for compatibility. Use\n",
+                            "`onshape_api_explain` to see the expected schema for each endpoint.",
+                        ),
+                    ),
+                    (
+                        "file_refs",
+                        concat!(
+                            "File references for fields whose content should be read from disk.\n",
+                            "\n",
+                            "Each reference specifies a file path, a body field name, and an encoding.\n",
+                            "The server reads the files and injects their content into the request body\n",
+                            "after building the request. Fields listed here should be omitted from `body`.\n",
+                            "\n",
+                            "Example: to upload a file via `uploadFileCreateElement`, pass the metadata\n",
+                            "fields in `body` and use `file_refs` for the binary content:\n",
+                            "`body: {\"formatName\": \"PARASOLID\"}`,\n",
+                            "`file_refs: [{\"path\": \"/tmp/part.x_t\", \"field\": \"file\", \"encoding\": \"raw_bytes\"}]`",
+                        ),
+                    ),
+                ],
+            },
+            ToolDefinition {
+                kind: ToolKind::Schema,
+                name: "onshape_api_schema",
+                description: concat!(
+                    "Look up an Onshape API schema by name. Returns the schema's properties (merged with ",
+                    "inherited parent properties), discriminator subtypes if polymorphic, and parent type. Use ",
+                    "schema names from x-bttype-options annotations in onshape_api_explain results to drill ",
+                    "into specific types.",
+                ),
+                input_description: Some("Input schema for `onshape_api_schema`."),
+                field_descriptions: &[(
+                    "schema",
+                    concat!(
+                        "The schema name to look up (e.g., `\"BTMParameterEnum-145\"` or\n",
+                        "`\"BTFeatureDefinitionCall-1406\"`). Use schema names from\n",
+                        "`x-bttype-options` annotations in `onshape_api_explain` results,\n",
+                        "or from the `subtypes` field in previous `onshape_api_schema` results.",
+                    ),
+                )],
+            },
+        ])
+        .expect("Onshape API tool configuration should be valid")
+    })
+}

--- a/crates/onshape-mcp-core/tests/fixtures/onshape-api-tools.json
+++ b/crates/onshape-mcp-core/tests/fixtures/onshape-api-tools.json
@@ -1,0 +1,184 @@
+[
+  {
+    "name": "onshape_api_search",
+    "description": "Find Onshape API endpoints by keyword or filter. Returns brief summaries (endpoint ID, method, path template, one-line description). Use this to discover available endpoints before calling onshape_api_explain for details.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Input schema for `onshape_api_search`.",
+      "properties": {
+        "method": {
+          "description": "Filter by HTTP method (e.g., \"GET\", \"POST\", \"DELETE\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "description": "Free-text search query. Matches against endpoint names, paths,\ndescriptions, and tags. Leave empty to list all endpoints.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Filter by tag name (e.g., \"Document\", \"Assembly\", \"`PartStudio`\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "ApiSearchInput",
+      "type": "object"
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false
+    }
+  },
+  {
+    "name": "onshape_api_explain",
+    "description": "Get full details for a specific Onshape API endpoint. Returns parameter schemas, types, required/optional flags, request/response schemas. Use the endpoint's operationId from onshape_api_search results.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Input schema for `onshape_api_explain`.",
+      "properties": {
+        "endpoint": {
+          "description": "The operation ID of the endpoint to explain (from search results).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "title": "ApiExplainInput",
+      "type": "object"
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false
+    }
+  },
+  {
+    "name": "onshape_api_call",
+    "description": "Invoke an Onshape API endpoint. Provide the operationId and structured parameters (path_params, query_params, body). Path parameters are named fields (e.g., {\"did\": \"abc123\"}), not baked into a URL string. For endpoints that accept file content (e.g., file uploads), use `file_refs` to reference local files instead of inlining content in the body — the server reads them directly. Returns the API response.",
+    "inputSchema": {
+      "$defs": {
+        "FileEncoding": {
+          "description": "How file content should be encoded when injected into a request body.\n\nThe encoding determines how raw file bytes are converted for the target\nfield. The appropriate encoding depends on the field type:\n\n- **Text fields** (JSON string values, multipart text parts): use [`TextUtf8`](FileEncoding::TextUtf8)\n- **Binary fields** (multipart `format: binary` parts): use [`RawBytes`](FileEncoding::RawBytes)\n- **Embedded binary in JSON**: use [`Base64`](FileEncoding::Base64)",
+          "oneOf": [
+            {
+              "const": "text_utf8",
+              "description": "Read the file as UTF-8 text.\n\nFor JSON bodies: injected as a JSON string value.\nFor multipart bodies: injected as a text form field.\n\nReturns an error if the file is not valid UTF-8.",
+              "type": "string"
+            },
+            {
+              "const": "base64",
+              "description": "Read the file as raw bytes and base64-encode.\n\nFor JSON bodies: injected as a base64-encoded JSON string value.\nFor multipart bodies: injected as a text form field containing base64.",
+              "type": "string"
+            },
+            {
+              "const": "raw_bytes",
+              "description": "Read the file as raw bytes (no encoding).\n\nFor multipart bodies: injected as a binary form field (`BinaryField`).\nFor JSON bodies: returns an error (raw bytes cannot be embedded in JSON).",
+              "type": "string"
+            }
+          ]
+        },
+        "FileReference": {
+          "description": "A reference to a file whose content should be injected into a request body field.\n\nInstead of the LLM reading a file into its context and inlining the content,\nthe server reads the file at execution time. This keeps large file content\nout of the LLM's context window.",
+          "properties": {
+            "encoding": {
+              "$ref": "#/$defs/FileEncoding",
+              "description": "How to encode the file content for the target field."
+            },
+            "field": {
+              "description": "The body field name to populate with the file content.\n\nFor JSON bodies, this is a top-level key in the JSON object.\nFor multipart bodies, this is the form field name.",
+              "type": "string"
+            },
+            "path": {
+              "description": "File system path to read. Must not be empty or contain `..` segments.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "field",
+            "encoding"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Input schema for `onshape_api_call`.",
+      "properties": {
+        "body": {
+          "description": "JSON value for the request body (for POST/PUT/PATCH endpoints).\nLegacy serialized JSON strings are also accepted for compatibility. Use\n`onshape_api_explain` to see the expected schema for each endpoint."
+        },
+        "endpoint": {
+          "description": "The operation ID of the endpoint to call.",
+          "type": "string"
+        },
+        "file_refs": {
+          "description": "File references for fields whose content should be read from disk.\n\nEach reference specifies a file path, a body field name, and an encoding.\nThe server reads the files and injects their content into the request body\nafter building the request. Fields listed here should be omitted from `body`.\n\nExample: to upload a file via `uploadFileCreateElement`, pass the metadata\nfields in `body` and use `file_refs` for the binary content:\n`body: {\"formatName\": \"PARASOLID\"}`,\n`file_refs: [{\"path\": \"/tmp/part.x_t\", \"field\": \"file\", \"encoding\": \"raw_bytes\"}]`",
+          "items": {
+            "$ref": "#/$defs/FileReference"
+          },
+          "type": "array"
+        },
+        "header_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Header parameters (e.g., `{\"Accept\": \"application/octet-stream\"}`).",
+          "type": "object"
+        },
+        "path_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Path parameters (e.g., `{\"did\": \"abc123\", \"wid\": \"def456\"}`).",
+          "type": "object"
+        },
+        "query_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Query parameters (e.g., `{\"q\": \"robot arm\", \"limit\": \"10\"}`).",
+          "type": "object"
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "title": "ApiCallInput",
+      "type": "object"
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true
+    }
+  },
+  {
+    "name": "onshape_api_schema",
+    "description": "Look up an Onshape API schema by name. Returns the schema's properties (merged with inherited parent properties), discriminator subtypes if polymorphic, and parent type. Use schema names from x-bttype-options annotations in onshape_api_explain results to drill into specific types.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Input schema for `onshape_api_schema`.",
+      "properties": {
+        "schema": {
+          "description": "The schema name to look up (e.g., `\"BTMParameterEnum-145\"` or\n`\"BTFeatureDefinitionCall-1406\"`). Use schema names from\n`x-bttype-options` annotations in `onshape_api_explain` results,\nor from the `subtypes` field in previous `onshape_api_schema` results.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema"
+      ],
+      "title": "ApiSchemaInput",
+      "type": "object"
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false
+    }
+  }
+]


### PR DESCRIPTION
The generic API handlers still depended on Onshape-owned input types and hardcoded tool metadata. Move those input types and schema generation into the generic API module, with host-supplied names, descriptions, and input-schema wording. One validated registry now supplies both discovery metadata and dispatch names for all four operations.

Onshape supplies its existing presentation through its adapter. Existing public input-type imports and published tool metadata remain unchanged. Description overrides only change wording; generated input constraints and operation-specific annotations remain owned by the generic layer. Configured names are checked against MCP's recommended character set and length limits before entering the registry.

Validation:

- All 276 core tests pass, including alternate-name dispatch for all four operations, neutral metadata, invalid configuration rejection, name boundaries and case sensitivity, and an Onshape metadata fixture captured before the refactor. The original refactor also passed the full 651-test workspace suite.
- Compared serialized metadata for all 11 tools before and after the change: byte-for-byte identical.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and `cargo fmt --all --check` pass.
