### PR TITLE
Separate generic API effect execution from Onshape I/O

### DIFF
--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -4,7 +4,7 @@
 //! Uses rmcp types directly to avoid unnecessary type conversions.
 //!
 //! Onshape request validation and diagnostic interpretation live in the private
-//! `onshape` module. The private `api` module handles `OpenAPI` search, explain,
+//! `onshape` module. The `api` module handles `OpenAPI` search, explain,
 //! schema lookup, and execution through its own effects and continuations.
 //! The Onshape adapter supplies validation and diagnostic policy and translates
 //! generic effects into the public dispatcher types used by the I/O layer.
@@ -19,8 +19,10 @@
 //! closures. After the I/O layer executes an effect, it calls [`resume()`] with
 //! the continuation and an [`IoResult`] to get the next effect.
 
-mod api;
+pub mod api;
 mod onshape;
+
+pub use onshape::API_POLICY as ONSHAPE_API_POLICY;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -174,6 +176,37 @@ pub enum ToolEffect {
         /// What to do with the read results.
         continuation: Continuation,
     },
+}
+
+impl ToolEffect {
+    /// Recover a generic API effect from the compatible Onshape representation.
+    ///
+    /// The I/O layer uses this to hand API continuations to the generic runner
+    /// while leaving authentication and screenshot continuations with the host.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original effect when it requires the Onshape dispatcher.
+    #[allow(clippy::result_large_err)] // Both branches move the existing effect without allocation.
+    pub fn into_api_effect(self) -> Result<api::Effect, Self> {
+        match self {
+            Self::ApiRequest {
+                request,
+                continuation: Continuation::FormatApiResponse,
+            } => Ok(api::Effect::ApiRequest {
+                request,
+                continuation: api::Continuation::FormatApiResponse,
+            }),
+            Self::ReadFiles {
+                reads,
+                continuation: Continuation::InjectFilesIntoRequest { request, file_refs },
+            } => Ok(api::Effect::ReadFiles {
+                reads,
+                continuation: api::Continuation::InjectFilesIntoRequest { request, file_refs },
+            }),
+            effect => Err(effect),
+        }
+    }
 }
 
 /// Plain-data continuation describing how to process an I/O result.

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -9,13 +9,12 @@ mod input;
 mod metadata;
 
 pub use input::{ApiCallInput, ApiExplainInput, ApiSchemaInput, ApiSearchInput};
-pub(super) use metadata::{ToolDefinition, ToolKind, ToolSet};
+pub use metadata::{ToolDefinition, ToolKind, ToolSet};
 
 use execution::tool_input_error;
-pub(super) use execution::{
-    Continuation, Effect, IoResult, Policy, process_api_response, resume, validate_file_path,
-};
+pub use execution::{Continuation, Effect, IoResult, Policy, resume};
 pub use execution::{FileEncoding, FileRead, FileReadResult, FileReference};
+pub(super) use execution::{process_api_response, validate_file_path};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -30,7 +29,8 @@ use rmcp::{
 use serde_json::{Map, Value};
 
 /// Dispatch a resolved API tool operation using the supplied host policy.
-pub(super) fn dispatch(
+#[must_use]
+pub fn dispatch(
     kind: ToolKind,
     arguments: Option<&Map<String, Value>>,
     spec: &OpenApiSpec,

--- a/crates/onshape-mcp-core/src/tools/api/metadata.rs
+++ b/crates/onshape-mcp-core/src/tools/api/metadata.rs
@@ -80,11 +80,13 @@ impl ToolSet {
     }
 
     /// Return the advertised tools in their configured order.
+    #[must_use]
     pub fn list(&self) -> Vec<Tool> {
         self.entries.iter().map(|(_, tool)| tool.clone()).collect()
     }
 
     /// Resolve an advertised name to its operation, leaving other names to the host.
+    #[must_use]
     pub fn resolve(&self, name: &str) -> Option<ToolKind> {
         self.entries
             .iter()

--- a/crates/onshape-mcp-io/src/api.rs
+++ b/crates/onshape-mcp-io/src/api.rs
@@ -1,0 +1,128 @@
+//! Execute generic API effects using a host-supplied request executor.
+//!
+//! Authentication, refresh, and host state updates belong to the executor.
+//! This runner reads permitted files and feeds I/O results back to the pure engine.
+
+#[cfg(test)]
+mod tests;
+
+use std::future::Future;
+
+use onshape_mcp_core::tools::api::{self, Effect, FileRead, FileReadResult, IoResult, Policy};
+use onshape_openapi::request::ApiRequest;
+use rmcp::{
+    ErrorData,
+    model::{CallToolResult, ContentBlock},
+};
+
+/// Raw HTTP response data passed back to the pure API engine.
+#[derive(Debug)]
+pub struct Response {
+    /// HTTP status code, including non-success statuses.
+    pub status: u16,
+    /// Response headers as name/value pairs.
+    pub headers: Vec<(String, String)>,
+    /// Unmodified response body bytes.
+    pub body: Vec<u8>,
+}
+
+/// A response to format, or a host result that completes the tool immediately.
+pub enum RequestOutcome {
+    /// Feed an HTTP response to the pending continuation.
+    Response(Response),
+    /// Return a host diagnostic, such as missing credentials, without resuming.
+    ToolResult(CallToolResult),
+}
+
+/// Host execution of neutral requests, including any authentication and state updates.
+pub trait RequestExecutor: Send {
+    /// Execute a request or return a host diagnostic that completes the tool.
+    ///
+    /// # Errors
+    ///
+    /// Return an MCP error for transport or infrastructure failures. HTTP error
+    /// statuses should be returned as responses for the pure engine to format.
+    fn execute(
+        &mut self,
+        request: ApiRequest,
+    ) -> impl Future<Output = Result<RequestOutcome, ErrorData>> + Send;
+}
+
+/// Whether the host permits local file reads for this invocation.
+pub enum FileReadPolicy<'a> {
+    /// Read the files requested by the pure engine.
+    Allow,
+    /// Complete with the host's tool-error diagnostic before touching the filesystem.
+    Deny(&'a str),
+}
+
+/// Run API effects to completion, resuming the pure engine after each I/O operation.
+///
+/// Host policy is supplied separately; continuations remain plain data.
+///
+/// # Errors
+///
+/// Propagates protocol errors from the engine and request executor. File read
+/// failures and denied access are returned as tool-level errors.
+pub async fn run(
+    initial_effect: Effect,
+    policy: &Policy,
+    executor: &mut impl RequestExecutor,
+    file_reads: FileReadPolicy<'_>,
+) -> Result<CallToolResult, ErrorData> {
+    let mut current = initial_effect;
+    loop {
+        current = match current {
+            Effect::Done(result) => return result,
+            Effect::ApiRequest {
+                request,
+                continuation,
+            } => match executor.execute(request).await? {
+                RequestOutcome::Response(response) => api::resume(
+                    continuation,
+                    IoResult::ApiResponse {
+                        status: response.status,
+                        headers: &response.headers,
+                        body: &response.body,
+                    },
+                    policy,
+                ),
+                RequestOutcome::ToolResult(result) => return Ok(result),
+            },
+            Effect::ReadFiles {
+                reads,
+                continuation,
+            } => {
+                let results = match read_files(&reads, &file_reads).await {
+                    Ok(results) => results,
+                    Err(result) => return Ok(result),
+                };
+                api::resume(continuation, IoResult::FileReadResults(&results), policy)
+            }
+        };
+    }
+}
+
+/// Apply host permission, then return one read result per requested file.
+pub(crate) async fn read_files(
+    reads: &[FileRead],
+    policy: &FileReadPolicy<'_>,
+) -> Result<Vec<FileReadResult>, CallToolResult> {
+    if let FileReadPolicy::Deny(message) = policy {
+        return Err(CallToolResult::error(vec![ContentBlock::text(*message)]));
+    }
+    let mut results = Vec::with_capacity(reads.len());
+    for read in reads {
+        match tokio::fs::read(&read.path).await {
+            Ok(data) => results.push(FileReadResult::Success {
+                path: read.path.clone(),
+                data,
+            }),
+            Err(error) => results.push(FileReadResult::Error {
+                path: read.path.clone(),
+                message: format!("failed to read file: {error}"),
+            }),
+        }
+    }
+    Ok(results)
+}

--- a/crates/onshape-mcp-io/src/api/tests.rs
+++ b/crates/onshape-mcp-io/src/api/tests.rs
@@ -1,0 +1,254 @@
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use onshape_mcp_core::tools::api::{Continuation, FileEncoding, FileReference};
+use onshape_openapi::request::RequestBody;
+use serde_json::{Value, json};
+
+use super::*;
+
+const POLICY: Policy = Policy {
+    validate_body: |_, _, _| Ok(()),
+    validate_request: |_| Ok(()),
+    append_error_details: |_, _| {},
+};
+
+#[derive(Default)]
+struct FakeExecutor {
+    requests: Vec<ApiRequest>,
+    outcome: Option<Result<RequestOutcome, ErrorData>>,
+}
+
+impl RequestExecutor for FakeExecutor {
+    fn execute(
+        &mut self,
+        request: ApiRequest,
+    ) -> impl Future<Output = Result<RequestOutcome, ErrorData>> + Send {
+        self.requests.push(request);
+        std::future::ready(self.outcome.take().expect("unexpected request execution"))
+    }
+}
+
+fn request() -> ApiRequest {
+    ApiRequest {
+        method: http::Method::PATCH,
+        path: "/items/a%2Fb".into(),
+        query_params: vec![
+            ("tag".into(), "first".into()),
+            ("tag".into(), "second".into()),
+        ],
+        headers: http::HeaderMap::from_iter([(
+            http::header::ACCEPT,
+            http::HeaderValue::from_static("application/octet-stream"),
+        )]),
+        body: Some(RequestBody::Json(json!({"title": "Example"}))),
+        content_type: Some("application/json".into()),
+    }
+}
+
+fn request_effect() -> Effect {
+    Effect::ApiRequest {
+        request: request(),
+        continuation: Continuation::FormatApiResponse,
+    }
+}
+
+fn file_effect(path: &Path) -> Effect {
+    Effect::ReadFiles {
+        reads: vec![FileRead {
+            path: path.to_path_buf(),
+        }],
+        continuation: Continuation::InjectFilesIntoRequest {
+            request: request(),
+            file_refs: vec![FileReference {
+                path: path.to_str().expect("UTF-8 test path").into(),
+                field: "content".into(),
+                encoding: FileEncoding::TextUtf8,
+            }],
+        },
+    }
+}
+
+fn text(result: &CallToolResult) -> &str {
+    &result.content[0].as_text().expect("text result").text
+}
+
+#[tokio::test]
+async fn files_are_injected_before_execution_and_binary_responses_are_preserved() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let path = dir.path().join("content.txt");
+    tokio::fs::write(&path, b"Uploaded content")
+        .await
+        .expect("write test file");
+    let mut executor = FakeExecutor {
+        outcome: Some(Ok(RequestOutcome::Response(Response {
+            status: 200,
+            headers: vec![("content-type".into(), "application/octet-stream".into())],
+            body: vec![0, 255],
+        }))),
+        ..FakeExecutor::default()
+    };
+
+    let result = run(
+        file_effect(&path),
+        &POLICY,
+        &mut executor,
+        FileReadPolicy::Allow,
+    )
+    .await
+    .expect("completed call");
+
+    assert_eq!(executor.requests.len(), 1);
+    let executed = &executor.requests[0];
+    let expected = request();
+    assert_eq!(executed.method, expected.method);
+    assert_eq!(executed.path, expected.path);
+    assert_eq!(executed.query_params, expected.query_params);
+    assert_eq!(executed.headers, expected.headers);
+    assert_eq!(executed.content_type, expected.content_type);
+    assert_eq!(
+        executed.body.as_ref().and_then(RequestBody::as_json),
+        Some(&json!({"title": "Example", "content": "Uploaded content"}))
+    );
+    assert_ne!(result.is_error, Some(true));
+    let body: Value = serde_json::from_str(text(&result)).expect("binary response metadata");
+    assert_eq!(body["encoding"], "base64");
+    assert_eq!(body["body"], "AP8=");
+}
+
+#[tokio::test]
+async fn denied_reads_return_host_wording_before_file_errors_or_requests() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let mut executor = FakeExecutor::default();
+    let result = run(
+        file_effect(&dir.path().join("missing.txt")),
+        &POLICY,
+        &mut executor,
+        FileReadPolicy::Deny("Local uploads are disabled by this host."),
+    )
+    .await
+    .expect("tool error");
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(text(&result), "Local uploads are disabled by this host.");
+    assert!(executor.requests.is_empty());
+}
+
+#[tokio::test]
+async fn read_failures_stop_before_request_execution() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let mut executor = FakeExecutor::default();
+    let result = run(
+        file_effect(&dir.path().join("missing.txt")),
+        &POLICY,
+        &mut executor,
+        FileReadPolicy::Allow,
+    )
+    .await
+    .expect("tool error");
+    assert_eq!(result.is_error, Some(true));
+    assert!(text(&result).contains("failed to read file:"));
+    assert!(executor.requests.is_empty());
+}
+
+#[tokio::test]
+async fn host_policy_can_reject_injected_content_before_request_execution() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let path = dir.path().join("content.txt");
+    tokio::fs::write(&path, b"Rejected content")
+        .await
+        .expect("write test file");
+    let policy = Policy {
+        validate_request: |request| {
+            assert_eq!(
+                request.body.as_ref().and_then(RequestBody::as_json),
+                Some(&json!({"title": "Example", "content": "Rejected content"}))
+            );
+            Err("Host rejected uploaded content.".into())
+        },
+        ..POLICY
+    };
+    let mut executor = FakeExecutor::default();
+    let result = run(
+        file_effect(&path),
+        &policy,
+        &mut executor,
+        FileReadPolicy::Allow,
+    )
+    .await
+    .expect("tool error");
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(text(&result), "Host rejected uploaded content.");
+    assert!(executor.requests.is_empty());
+}
+
+#[tokio::test]
+async fn engine_and_executor_terminal_results_are_returned_unchanged() {
+    for expected in [
+        Ok(CallToolResult::error(vec![ContentBlock::text(
+            "Host credentials are missing.",
+        )])),
+        Err(ErrorData::internal_error("Connection failed.", None)),
+    ] {
+        let mut executor = FakeExecutor::default();
+        let result = run(
+            Effect::Done(expected.clone()),
+            &POLICY,
+            &mut executor,
+            FileReadPolicy::Allow,
+        )
+        .await;
+        assert_eq!(
+            serde_json::to_value(&result).expect("result"),
+            serde_json::to_value(&expected).expect("expected result")
+        );
+        assert!(executor.requests.is_empty());
+
+        executor.outcome = Some(expected.clone().map(RequestOutcome::ToolResult));
+        let result = run(
+            request_effect(),
+            &POLICY,
+            &mut executor,
+            FileReadPolicy::Allow,
+        )
+        .await;
+        assert_eq!(
+            serde_json::to_value(result).expect("result"),
+            serde_json::to_value(expected).expect("expected result")
+        );
+        assert_eq!(executor.requests.len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn http_errors_retain_response_headers_and_host_diagnostics() {
+    let mut executor = FakeExecutor {
+        outcome: Some(Ok(RequestOutcome::Response(Response {
+            status: 429,
+            headers: vec![("retry-after".into(), "30".into())],
+            body: vec![0, 255],
+        }))),
+        ..FakeExecutor::default()
+    };
+    let policy = Policy {
+        append_error_details: |message, bytes| {
+            assert_eq!(bytes, &[0, 255]);
+            message.push_str("; host_code=BUSY");
+        },
+        ..POLICY
+    };
+    let result = run(
+        request_effect(),
+        &policy,
+        &mut executor,
+        FileReadPolicy::Allow,
+    )
+    .await
+    .expect("tool error");
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(
+        text(&result),
+        "API error (HTTP 429): category=rate_limited; transient=true; host_code=BUSY; retry_after_seconds=30"
+    );
+    assert_eq!(executor.requests.len(), 1);
+}

--- a/crates/onshape-mcp-io/src/api_adapter_tests.rs
+++ b/crates/onshape-mcp-io/src/api_adapter_tests.rs
@@ -1,0 +1,225 @@
+//! Verify the Onshape boundary around the generic API runner.
+
+#![allow(clippy::expect_used)]
+
+use onshape_mcp_core::{
+    ValidationStatus,
+    tools::{Continuation, FileEncoding, FileReference},
+};
+use onshape_openapi::request::{ApiRequest, RequestBody};
+use serde_json::json;
+
+use super::*;
+
+fn request() -> ApiRequest {
+    ApiRequest {
+        method: http::Method::POST,
+        path: "/documents".into(),
+        query_params: vec![],
+        headers: http::HeaderMap::new(),
+        body: Some(RequestBody::Json(json!({}))),
+        content_type: Some("application/json".into()),
+    }
+}
+
+fn unconfigured() -> ApiState {
+    ApiState::NotConfigured {
+        configured_method: AuthMethod::Auto,
+        detail: "test".into(),
+    }
+}
+
+fn text(result: &CallToolResult) -> &str {
+    &result.content[0].as_text().expect("text result").text
+}
+
+#[tokio::test]
+async fn file_calls_preserve_transport_restrictions_and_onshape_validation_order() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let path = dir.path().join("name.txt");
+    for (allow_reads, contents, expected) in [
+        (
+            false,
+            "Example",
+            "File read operations are not supported over the HTTP transport.",
+        ),
+        (true, "", "createDocument name must not be blank"),
+        (
+            true,
+            "Example",
+            "Cannot execute API call: credentials are not configured.",
+        ),
+    ] {
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("write test name");
+        let effect = ToolEffect::ReadFiles {
+            reads: vec![tools::FileRead { path: path.clone() }],
+            continuation: Continuation::InjectFilesIntoRequest {
+                request: request(),
+                file_refs: vec![FileReference {
+                    path: path.to_str().expect("UTF-8 test path").into(),
+                    field: "name".into(),
+                    encoding: FileEncoding::TextUtf8,
+                }],
+            },
+        };
+        let validation = tokio::sync::Mutex::new(ValidationState::default());
+        let result = dispatch_tool_effect(
+            effect,
+            &mut unconfigured(),
+            &validation,
+            None,
+            false,
+            allow_reads,
+        )
+        .await
+        .expect("tool error");
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            text(&result).contains(expected),
+            "unexpected result: {}",
+            text(&result)
+        );
+        assert_eq!(
+            validation.lock().await.status,
+            ValidationStatus::NotValidated
+        );
+    }
+}
+
+#[tokio::test]
+async fn unavailable_credentials_complete_generic_and_host_calls_without_http() {
+    for pending in [false, true] {
+        for continuation in [
+            Continuation::FormatApiResponse,
+            Continuation::ProcessAuthValidation {
+                resolved_auth: ResolvedAuth::Basic,
+            },
+        ] {
+            let mut state = if pending {
+                ApiState::OAuthPending(Box::new(OAuthPendingState {
+                    refresh_method: PendingRefreshMethod::Proxy {
+                        proxy_url: "https://proxy.example.com".into(),
+                    },
+                    base_url: "https://api.example.com".into(),
+                    timeout: Duration::from_secs(1),
+                    token_path: PathBuf::from("unused-tokens.json"),
+                }))
+            } else {
+                unconfigured()
+            };
+            let validation = tokio::sync::Mutex::new(ValidationState::default());
+            let effect = ToolEffect::ApiRequest {
+                request: request(),
+                continuation,
+            };
+            let result = dispatch_tool_effect(effect, &mut state, &validation, None, false, false)
+                .await
+                .expect("credential diagnostic");
+            let expected = if pending {
+                oauth_pending_error()
+            } else {
+                not_configured_error()
+            };
+            assert_eq!(
+                serde_json::to_value(result).expect("result"),
+                serde_json::to_value(expected).expect("expected result")
+            );
+            let validation = validation.lock().await.clone();
+            assert_eq!(validation.status, ValidationStatus::NotValidated);
+            assert!(validation.last_check.is_none());
+        }
+    }
+}
+
+#[tokio::test]
+async fn generic_and_host_continuations_share_authenticated_execution_and_validation() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test API");
+    let address = listener.local_addr().expect("test API address");
+    let app =
+        axum::Router::new().route(
+            "/status/{code}",
+            axum::routing::get(
+                |axum::extract::Path(status): axum::extract::Path<u16>,
+                 headers: http::HeaderMap| async move {
+                    assert_eq!(headers[http::header::AUTHORIZATION], "Bearer test-access");
+                    (
+                        http::StatusCode::from_u16(status).expect("test status"),
+                        axum::Json(json!({"ok": true})),
+                    )
+                },
+            ),
+        );
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test API");
+    });
+    let client = OnshapeClient::new(ClientConfig {
+        base_url: format!("http://{address}"),
+        auth: ClientAuthConfig::Bearer {
+            access_token: AccessToken::new("test-access".into()),
+        },
+        timeout: Some(Duration::from_secs(5)),
+    })
+    .expect("test client");
+    let mut state = ApiState::Basic(client);
+    for (status, expected) in [
+        (200, ValidationStatus::Valid),
+        (401, ValidationStatus::Invalid),
+        (503, ValidationStatus::NotValidated),
+    ] {
+        for host_continuation in [false, true] {
+            let validation = tokio::sync::Mutex::new(ValidationState::default());
+            let mut request = request();
+            request.method = http::Method::GET;
+            request.path = format!("/status/{status}");
+            request.body = None;
+            request.content_type = None;
+            let continuation = if host_continuation {
+                Continuation::ProcessAuthValidation {
+                    resolved_auth: ResolvedAuth::Basic,
+                }
+            } else {
+                Continuation::FormatApiResponse
+            };
+            let result = dispatch_tool_effect(
+                ToolEffect::ApiRequest {
+                    request,
+                    continuation,
+                },
+                &mut state,
+                &validation,
+                None,
+                false,
+                false,
+            )
+            .await
+            .expect("completed request");
+            let validation = validation.lock().await.clone();
+            assert_eq!(validation.status, expected);
+            assert_eq!(validation.last_check.is_some(), status != 503);
+            if host_continuation {
+                assert_ne!(result.is_error, Some(true));
+                if status == 200 {
+                    assert_eq!(
+                        validation.message.as_deref(),
+                        Some("Credentials validated successfully")
+                    );
+                }
+            } else {
+                assert_eq!(result.is_error, Some(status >= 400));
+                if status == 200 {
+                    assert!(validation.message.is_none());
+                    assert_eq!(
+                        serde_json::from_str::<serde_json::Value>(text(&result))
+                            .expect("JSON result"),
+                        json!({"ok": true})
+                    );
+                }
+            }
+        }
+    }
+    server.abort();
+}

--- a/crates/onshape-mcp-io/src/lib.rs
+++ b/crates/onshape-mcp-io/src/lib.rs
@@ -4,12 +4,16 @@
 //! It delegates all tool logic to `onshape-mcp-core` and HTTP execution to
 //! `onshape-client-io`.
 
+pub mod api;
 pub mod config;
 pub mod login;
 pub mod oauth;
 pub mod oauth_server;
 mod request;
 pub mod watcher;
+
+#[cfg(test)]
+mod api_adapter_tests;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -44,6 +48,7 @@ use onshape_mcp_core::tools::{self, IoResult, SideEffect, ToolEffect};
 use onshape_openapi::OpenApiSpec;
 
 use crate::oauth::{McpOAuthTokenFile, McpOAuthTokenMetadata, default_token_file_path};
+use api::{RequestExecutor as _, Response as RawResponse};
 
 /// The embedded Onshape `OpenAPI` specification JSON.
 ///
@@ -656,9 +661,8 @@ impl OnshapeMcpServer {
 /// Handles `Done`, `ApiRequest`, `OAuthLoginFlow`, `WriteFiles`, and `ReadFiles`
 /// variants. Used by both stdio and HTTP modes.
 ///
-/// After executing an `ApiRequest`, `WriteFiles`, or `ReadFiles` effect, calls
-/// [`tools::resume()`] with the continuation and the I/O result to get the
-/// next effect, then loops.
+/// Generic API continuations are handed to [`api::run`]. Host continuations
+/// resume through [`tools::resume()`], applying any Onshape side effects.
 ///
 /// `allow_file_writes` and `allow_file_reads` control whether file I/O effects
 /// are executed. The stdio transport passes `true` for both (local, single-user
@@ -673,20 +677,32 @@ async fn dispatch_tool_effect(
     allow_file_writes: bool,
     allow_file_reads: bool,
 ) -> Result<CallToolResult, McpError> {
+    let file_reads = if allow_file_reads {
+        api::FileReadPolicy::Allow
+    } else {
+        api::FileReadPolicy::Deny(
+            "File read operations are not supported over the HTTP transport. \
+             File references in onshape_api_call require the stdio transport \
+             (local process).",
+        )
+    };
     let mut current = initial_effect;
     loop {
-        // For variants that need API execution, check if credentials
-        // are available. NotConfigured and OAuthPending cannot execute
-        // API requests, so return informative tool-level errors.
-        if matches!(current, ToolEffect::ApiRequest { .. }) {
-            match state {
-                ApiState::NotConfigured { .. } => return Ok(not_configured_error()),
-                ApiState::OAuthPending(_) => return Ok(oauth_pending_error()),
-                ApiState::Basic(_) | ApiState::OAuth(_) | ApiState::HttpOAuth(_) => {}
+        let mut executor = request::Executor { state, validation };
+        let host_effect = match current.into_api_effect() {
+            Ok(effect) => {
+                return api::run(
+                    effect,
+                    &tools::ONSHAPE_API_POLICY,
+                    &mut executor,
+                    file_reads,
+                )
+                .await;
             }
-        }
+            Err(effect) => effect,
+        };
 
-        match current {
+        match host_effect {
             ToolEffect::Done(r) => return r,
             ToolEffect::OAuthLoginFlow { mode } => {
                 // In HTTP mode, login_state is None — return informative message.
@@ -704,25 +720,18 @@ async fn dispatch_tool_effect(
             ToolEffect::ApiRequest {
                 request: api_req,
                 continuation,
-            } => {
-                let api_req = request::into_onshape_request(api_req);
-                let raw = execute_raw_api_request(state, &api_req).await;
-                match raw {
-                    Ok(raw) => {
-                        update_implicit_validation(validation, raw.status).await;
+            } => match executor.execute(api_req).await? {
+                api::RequestOutcome::Response(raw) => {
+                    let (next_effect, side_effects) = resume_with_raw_response(continuation, &raw);
 
-                        let (next_effect, side_effects) =
-                            resume_with_raw_response(continuation, &raw);
-
-                        for effect in side_effects {
-                            apply_side_effect(validation, effect).await;
-                        }
-
-                        current = next_effect;
+                    for effect in side_effects {
+                        apply_side_effect(validation, effect).await;
                     }
-                    Err(e) => return Err(e),
+
+                    current = next_effect;
                 }
-            }
+                api::RequestOutcome::ToolResult(result) => return Ok(result),
+            },
             ToolEffect::WriteFiles {
                 files,
                 continuation,
@@ -751,16 +760,10 @@ async fn dispatch_tool_effect(
                 reads,
                 continuation,
             } => {
-                if !allow_file_reads {
-                    return Ok(CallToolResult::error(vec![
-                        rmcp::model::ContentBlock::text(
-                            "File read operations are not supported over the HTTP transport. \
-                         File references in onshape_api_call require the stdio transport \
-                         (local process).",
-                        ),
-                    ]));
-                }
-                let results = read_files(&reads).await;
+                let results = match api::read_files(&reads, &file_reads).await {
+                    Ok(results) => results,
+                    Err(result) => return Ok(result),
+                };
 
                 let (next_effect, side_effects) =
                     tools::resume(continuation, IoResult::FileReadResults(&results));
@@ -815,44 +818,8 @@ async fn write_files(files: &[tools::FileWrite]) -> Vec<tools::FileWriteResult> 
 }
 
 // ============================================================================
-// File Read Execution
-// ============================================================================
-
-/// Read files from disk as requested by [`ToolEffect::ReadFiles`].
-///
-/// Returns one [`tools::FileReadResult`] per input file.
-async fn read_files(reads: &[tools::FileRead]) -> Vec<tools::FileReadResult> {
-    let mut results = Vec::with_capacity(reads.len());
-    for read in reads {
-        match tokio::fs::read(&read.path).await {
-            Ok(data) => {
-                results.push(tools::FileReadResult::Success {
-                    path: read.path.clone(),
-                    data,
-                });
-            }
-            Err(e) => {
-                results.push(tools::FileReadResult::Error {
-                    path: read.path.clone(),
-                    message: format!("failed to read file: {e}"),
-                });
-            }
-        }
-    }
-    results
-}
-
-// ============================================================================
 // API Request Execution
 // ============================================================================
-
-/// Result of executing a raw API request: HTTP status code, headers, and bytes.
-#[derive(Debug)]
-struct RawResponse {
-    status: u16,
-    headers: Vec<(String, String)>,
-    body: Vec<u8>,
-}
 
 fn raw_response_from_api_response(response: ApiResponse) -> RawResponse {
     RawResponse {

--- a/crates/onshape-mcp-io/src/request.rs
+++ b/crates/onshape-mcp-io/src/request.rs
@@ -3,6 +3,37 @@
 use onshape_client_core::request as client;
 use onshape_openapi::request as openapi;
 
+use super::{ApiState, McpError, ValidationState, api};
+
+/// Execute requests with Onshape authentication and update host validation state.
+pub struct Executor<'a> {
+    pub state: &'a mut ApiState,
+    pub validation: &'a tokio::sync::Mutex<ValidationState>,
+}
+
+impl api::RequestExecutor for Executor<'_> {
+    async fn execute(
+        &mut self,
+        request: openapi::ApiRequest,
+    ) -> Result<api::RequestOutcome, McpError> {
+        match self.state {
+            ApiState::NotConfigured { .. } => {
+                return Ok(api::RequestOutcome::ToolResult(
+                    super::not_configured_error(),
+                ));
+            }
+            ApiState::OAuthPending(_) => {
+                return Ok(api::RequestOutcome::ToolResult(super::oauth_pending_error()));
+            }
+            ApiState::Basic(_) | ApiState::OAuth(_) | ApiState::HttpOAuth(_) => {}
+        }
+        let request = into_onshape_request(request);
+        let response = super::execute_raw_api_request(self.state, &request).await?;
+        super::update_implicit_validation(self.validation, response.status).await;
+        Ok(api::RequestOutcome::Response(response))
+    }
+}
+
 /// Move request data into the Onshape client representation without serialization.
 pub fn into_onshape_request(request: openapi::ApiRequest) -> client::ApiRequest {
     let openapi::ApiRequest {

--- a/docs/src/project/architecture.md
+++ b/docs/src/project/architecture.md
@@ -26,6 +26,13 @@
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+Generic API execution is split between `onshape_mcp_core::tools::api`, which
+produces and resumes plain-data effects, and `onshape_mcp_io::api`, which runs
+those effects. The runner accepts a host request executor and file-read policy.
+Onshape's executor handles credentials, token refresh, and validation updates;
+its dispatcher retains auth and screenshot continuations. Existing public
+Onshape effects are adapted to the generic runner at the I/O boundary.
+
 See [Data Flow](data-flow.md) for sequence diagrams showing how requests,
 authentication, and token refresh flow through each operating mode.
 


### PR DESCRIPTION
Generic API effects still relied on Onshape's async dispatcher for file reads and HTTP execution. Add a reusable runner that resumes the pure API engine using a host-supplied request executor and file-read policy. The runner handles neutral request/response data, file reads, and terminal results.

Both stdio and HTTP dispatch now hand generic API continuations to this runner. Onshape's executor handles credential availability, the existing Basic/OAuth execution and refresh paths, and implicit validation updates. Auth and screenshot continuations stay in the host dispatcher, including their side effects. Existing public Onshape effect/continuation shapes are preserved through an adapter at the I/O boundary.

Validation:

- All 662 workspace tests pass (`cargo test --workspace --all-features --locked --offline`).
- Six runner tests use a fake request executor to cover file injection, binary responses, denied/failed reads, host policy rejection, terminal results, and HTTP error diagnostics.
- Three adapter tests cover missing/pending credentials, file-access and validation ordering, authenticated execution, and validation updates for generic and host continuations.
- Workspace Clippy with warnings denied and formatting checks pass.
