### PR TITLE
Exercise generic API tools against a non-Onshape HTTP fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -510,6 +511,15 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -1227,6 +1237,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -2186,6 +2213,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "sse-stream"

--- a/crates/onshape-mcp-io/Cargo.toml
+++ b/crates/onshape-mcp-io/Cargo.toml
@@ -41,6 +41,7 @@ tower-http.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+axum = { workspace = true, features = ["multipart"] }
 tempfile.workspace = true
 toml.workspace = true
 tower.workspace = true

--- a/crates/onshape-mcp-io/tests/fixtures/media-catalog.json
+++ b/crates/onshape-mcp-io/tests/fixtures/media-catalog.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.1",
+  "info": { "title": "Media Catalog", "version": "1.0" },
+  "servers": [{ "url": "https://media.example.invalid/api/v2/" }],
+  "paths": {
+    "/collections/{collection_id}/items/{item_id}": {
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update an item in a collection",
+        "tags": ["Catalog"],
+        "parameters": [
+          { "name": "collection_id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "item_id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "note", "in": "query", "schema": { "type": "string" } },
+          { "name": "X-Workspace", "in": "header", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ItemPatch" } } }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated item",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ItemPatch" } } }
+          }
+        }
+      }
+    },
+    "/collections/{collection_id}/assets": {
+      "post": {
+        "operationId": "uploadAsset",
+        "summary": "Upload binary content to a collection",
+        "tags": ["Assets"],
+        "parameters": [
+          { "name": "collection_id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": { "type": "string" },
+                  "file": { "type": "string", "format": "binary" }
+                },
+                "required": ["label", "file"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Uploaded asset" } }
+      }
+    },
+    "/assets/{asset_id}/content": {
+      "get": {
+        "operationId": "downloadAsset",
+        "summary": "Download the original asset bytes",
+        "tags": ["Assets"],
+        "parameters": [
+          { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Original asset",
+            "content": { "application/octet-stream": { "schema": { "type": "string", "format": "binary" } } }
+          }
+        }
+      }
+    },
+    "/busy": {
+      "get": {
+        "operationId": "checkCapacity",
+        "summary": "Check catalog capacity",
+        "responses": { "503": { "description": "Capacity temporarily unavailable" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ItemPatch": {
+        "type": "object",
+        "description": "Editable media item metadata.",
+        "properties": { "title": { "type": "string" } },
+        "required": ["title"]
+      }
+    }
+  }
+}

--- a/crates/onshape-mcp-io/tests/generic_api.rs
+++ b/crates/onshape-mcp-io/tests/generic_api.rs
@@ -1,0 +1,232 @@
+//! Exercise a non-Onshape API through public metadata, dispatch, and runner interfaces.
+
+#![allow(clippy::expect_used)]
+
+#[path = "support/media_catalog.rs"]
+mod media_catalog;
+
+use std::collections::HashMap;
+
+use base64::Engine;
+use http::{Method, header};
+use onshape_mcp_io::api::FileReadPolicy;
+use rmcp::model::CallToolResult;
+use serde_json::{Value, json};
+
+use media_catalog::{BINARY_CONTENT, Catalog, TOOL_NAMES};
+
+fn text(result: &CallToolResult) -> &str {
+    &result.content[0].as_text().expect("text content").text
+}
+
+fn json_result(result: &CallToolResult) -> Value {
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "unexpected tool error: {}",
+        text(result)
+    );
+    serde_json::from_str(text(result)).expect("JSON result")
+}
+
+#[tokio::test]
+async fn catalog_tools_and_json_calls_work_with_alternate_names() {
+    let mut catalog = Catalog::start().await;
+    let advertised = catalog.tools.list();
+    assert_eq!(
+        advertised
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        TOOL_NAMES
+    );
+    let metadata = serde_json::to_string(&advertised).expect("tool metadata");
+    assert!(!metadata.to_lowercase().contains("onshape"));
+
+    let search = catalog
+        .invoke(
+            "media.find",
+            json!({"query": "updateItem"}),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    let endpoints = json_result(&search);
+    assert_eq!(endpoints.as_array().expect("search results").len(), 1);
+    let endpoint = endpoints[0]["operation_id"].as_str().expect("operation ID");
+    assert_eq!(endpoint, "updateItem");
+    let explanation = catalog
+        .invoke(
+            "media.describe",
+            json!({"endpoint": endpoint}),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    let explanation = json_result(&explanation);
+    assert_eq!(explanation["method"], "PATCH");
+    assert_eq!(
+        explanation["path"],
+        "/collections/{collection_id}/items/{item_id}"
+    );
+    assert_eq!(
+        explanation["request_body_schema"]["properties"]["title"]["type"],
+        "string"
+    );
+    let schema = catalog
+        .invoke(
+            "media.type",
+            json!({"schema": "ItemPatch"}),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    let schema = json_result(&schema);
+    assert_eq!(schema["name"], "ItemPatch");
+    assert_eq!(schema["properties"]["title"]["type"], "string");
+    assert_eq!(schema["required"], json!(["title"]));
+    assert!(
+        catalog.requests().await.is_empty(),
+        "catalog tools must not execute HTTP requests"
+    );
+
+    let body = json!({"title": "A media item"});
+    let result = catalog
+        .invoke(
+            "media.send",
+            json!({
+                "endpoint": endpoint,
+                "path_params": {"collection_id": "shelf/one", "item_id": "item two"},
+                "query_params": {"note": "a & b/+?"},
+                "header_params": {"X-Workspace": "sandbox"},
+                "body": body,
+            }),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    assert_eq!(json_result(&result), body);
+    let requests = catalog.requests().await;
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+    assert_eq!(request.method, Method::PATCH);
+    assert_eq!(
+        request.uri.path(),
+        "/api/v2/collections/shelf%2Fone/items/item%20two"
+    );
+    let query: HashMap<_, _> =
+        url::form_urlencoded::parse(request.uri.query().expect("query").as_bytes())
+            .into_owned()
+            .collect();
+    assert_eq!(query, HashMap::from([("note".into(), "a & b/+?".into())]));
+    assert_eq!(request.headers["x-workspace"], "sandbox");
+    assert_eq!(request.headers[header::CONTENT_TYPE], "application/json");
+    assert!(!request.headers.contains_key(header::AUTHORIZATION));
+}
+
+#[tokio::test]
+async fn local_files_reach_the_api_as_binary_multipart_parts() {
+    let mut catalog = Catalog::start().await;
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("asset.bin");
+    tokio::fs::write(&path, BINARY_CONTENT)
+        .await
+        .expect("write asset");
+    let result = catalog
+        .invoke(
+            "media.send",
+            json!({
+                "endpoint": "uploadAsset",
+                "path_params": {"collection_id": "shelf"},
+                "body": {"label": "Sample asset"},
+                "file_refs": [{"path": path, "field": "file", "encoding": "raw_bytes"}],
+            }),
+            FileReadPolicy::Allow,
+        )
+        .await;
+    let parts = json_result(&result);
+    let parts = parts.as_array().expect("parsed multipart parts");
+    assert_eq!(parts.len(), 2);
+    let fields: HashMap<_, _> = parts
+        .iter()
+        .map(|part| (part["name"].as_str().expect("part name"), &part["data"]))
+        .collect();
+    assert_eq!(fields["label"], &json!(b"Sample asset".as_slice()));
+    assert_eq!(fields["file"], &json!(BINARY_CONTENT));
+    let requests = catalog.requests().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, Method::POST);
+    assert_eq!(requests[0].uri.path(), "/api/v2/collections/shelf/assets");
+    assert!(
+        requests[0].headers[header::CONTENT_TYPE]
+            .to_str()
+            .expect("content type")
+            .starts_with("multipart/form-data; boundary=")
+    );
+    assert!(!requests[0].headers.contains_key(header::AUTHORIZATION));
+}
+
+#[tokio::test]
+async fn binary_and_error_responses_preserve_http_semantics() {
+    let mut catalog = Catalog::start().await;
+    let result = catalog
+        .invoke(
+            "media.send",
+            json!({
+                "endpoint": "downloadAsset", "path_params": {"asset_id": "asset-1"},
+            }),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    let binary = json_result(&result);
+    assert_eq!(binary["encoding"], "base64");
+    assert_eq!(binary["contentType"], "application/octet-stream");
+    assert_eq!(binary["status"], 200);
+    assert_eq!(binary["byteLength"], BINARY_CONTENT.len());
+    assert_eq!(
+        base64::engine::general_purpose::STANDARD
+            .decode(binary["body"].as_str().expect("encoded bytes"))
+            .expect("base64 response"),
+        BINARY_CONTENT
+    );
+
+    let result = catalog
+        .invoke(
+            "media.send",
+            json!({"endpoint": "checkCapacity"}),
+            FileReadPolicy::Deny("No local files."),
+        )
+        .await;
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(
+        text(&result),
+        "API error (HTTP 503): category=service_unavailable; transient=true; retry_after_seconds=7"
+    );
+    let requests = catalog.requests().await;
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method, Method::GET);
+    assert_eq!(requests[0].uri.path(), "/api/v2/assets/asset-1/content");
+    assert_eq!(
+        requests[0].headers[header::ACCEPT],
+        "application/octet-stream"
+    );
+    assert_eq!(requests[1].uri.path(), "/api/v2/busy");
+}
+
+#[tokio::test]
+async fn denied_file_reads_return_host_diagnostics_without_http() {
+    let mut catalog = Catalog::start().await;
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("missing.bin");
+    let result = catalog
+        .invoke(
+            "media.send",
+            json!({
+                "endpoint": "uploadAsset",
+                "path_params": {"collection_id": "shelf"},
+                "body": {"label": "Not uploaded"},
+                "file_refs": [{"path": path, "field": "file", "encoding": "raw_bytes"}],
+            }),
+            FileReadPolicy::Deny("Local uploads are disabled by this host."),
+        )
+        .await;
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(text(&result), "Local uploads are disabled by this host.");
+    assert!(catalog.requests().await.is_empty());
+}

--- a/crates/onshape-mcp-io/tests/support/media_catalog.rs
+++ b/crates/onshape-mcp-io/tests/support/media_catalog.rs
@@ -1,0 +1,264 @@
+//! A local media API and test executor using only the public generic interfaces.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Json, Router,
+    extract::{Multipart, Request, State},
+    middleware::{self, Next},
+    response::Response as HttpResponse,
+    routing::{get, patch, post},
+};
+use http::{HeaderMap, Method, StatusCode, Uri, header};
+use onshape_mcp_core::tools::api::{self, Policy, ToolDefinition, ToolKind, ToolSet};
+use onshape_mcp_io::api::{FileReadPolicy, RequestExecutor, RequestOutcome, Response, run};
+use onshape_openapi::{
+    OpenApiSpec,
+    request::{ApiRequest, RequestBody},
+};
+use rmcp::{ErrorData, model::CallToolResult};
+use serde_json::{Value, json};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+pub const BINARY_CONTENT: &[u8] = &[0, 255, 10, 13, 128];
+pub const TOOL_NAMES: [&str; 4] = ["media.find", "media.describe", "media.send", "media.type"];
+
+const POLICY: Policy = Policy {
+    validate_body: |_, _, _| Ok(()),
+    validate_request: |_| Ok(()),
+    append_error_details: |_, _| {},
+};
+
+/// Record the request as received by the server, before routing or body parsing.
+#[derive(Clone, Debug)]
+pub struct ObservedRequest {
+    pub method: Method,
+    pub uri: Uri,
+    pub headers: HeaderMap,
+}
+
+type Observations = Arc<Mutex<Vec<ObservedRequest>>>;
+
+async fn observe(
+    State(observations): State<Observations>,
+    request: Request,
+    next: Next,
+) -> HttpResponse {
+    observations.lock().await.push(ObservedRequest {
+        method: request.method().clone(),
+        uri: request.uri().clone(),
+        headers: request.headers().clone(),
+    });
+    next.run(request).await
+}
+
+/// Echo parsed multipart parts so tests can check the bytes and field names.
+async fn upload(mut multipart: Multipart) -> (StatusCode, Json<Value>) {
+    let mut parts = Vec::new();
+    while let Some(field) = multipart.next_field().await.expect("valid multipart field") {
+        let name = field.name().expect("named form field").to_owned();
+        let data = field.bytes().await.expect("complete form field");
+        parts.push(json!({"name": name, "data": data.to_vec()}));
+    }
+    (StatusCode::CREATED, Json(json!(parts)))
+}
+
+fn tools() -> ToolSet {
+    ToolSet::new(&[
+        ToolDefinition {
+            kind: ToolKind::Search,
+            name: TOOL_NAMES[0],
+            description: "Find media operations, then inspect them with media.describe.",
+            input_description: None,
+            field_descriptions: &[],
+        },
+        ToolDefinition {
+            kind: ToolKind::Explain,
+            name: TOOL_NAMES[1],
+            description: "Explain a media operation found with media.find.",
+            input_description: None,
+            field_descriptions: &[],
+        },
+        ToolDefinition {
+            kind: ToolKind::Call,
+            name: TOOL_NAMES[2],
+            description: "Send a media request described by media.describe.",
+            input_description: None,
+            field_descriptions: &[("body", "Use media.describe to inspect the request schema.")],
+        },
+        ToolDefinition {
+            kind: ToolKind::Schema,
+            name: TOOL_NAMES[3],
+            description: "Inspect a media component schema.",
+            input_description: None,
+            field_descriptions: &[],
+        },
+    ])
+    .expect("valid media tool configuration")
+}
+
+/// Test-only HTTP execution; deliberately independent of the Onshape client and auth.
+struct HttpExecutor {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+fn execution_error(error: impl std::fmt::Display) -> ErrorData {
+    ErrorData::internal_error(format!("fixture HTTP execution failed: {error}"), None)
+}
+
+impl RequestExecutor for HttpExecutor {
+    async fn execute(&mut self, request: ApiRequest) -> Result<RequestOutcome, ErrorData> {
+        // OpenAPI paths begin with '/'; retain the server URL's path prefix.
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), request.path);
+        let mut builder = self
+            .client
+            .request(request.method, url)
+            .query(&request.query_params)
+            .headers(request.headers);
+        match request.body {
+            Some(RequestBody::Json(body)) => {
+                builder = builder
+                    .header(
+                        header::CONTENT_TYPE,
+                        request
+                            .content_type
+                            .as_deref()
+                            .unwrap_or("application/json"),
+                    )
+                    .body(serde_json::to_vec(&body).map_err(execution_error)?);
+            }
+            Some(RequestBody::Multipart(body)) => {
+                let mut form = reqwest::multipart::Form::new();
+                for (name, value) in body.text_fields {
+                    form = form.text(name, value);
+                }
+                for field in body.binary_fields {
+                    let mut part = reqwest::multipart::Part::bytes(field.data);
+                    if let Some(content_type) = field.content_type {
+                        part = part.mime_str(&content_type).map_err(execution_error)?;
+                    }
+                    form = form.part(field.field_name, part);
+                }
+                // Let reqwest supply the multipart boundary in Content-Type.
+                builder = builder.multipart(form);
+            }
+            None => {}
+        }
+        let response = builder.send().await.map_err(execution_error)?;
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.to_string(),
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect();
+        let body = response.bytes().await.map_err(execution_error)?.to_vec();
+        Ok(RequestOutcome::Response(Response {
+            status,
+            headers,
+            body,
+        }))
+    }
+}
+
+/// Own the API server for one test and stop it even when an assertion fails.
+pub struct Catalog {
+    pub tools: ToolSet,
+    spec: OpenApiSpec,
+    executor: HttpExecutor,
+    observations: Observations,
+    server: JoinHandle<()>,
+}
+
+impl Catalog {
+    pub async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind media API");
+        let address = listener.local_addr().expect("media API address");
+        let observations = Observations::default();
+        let app = Router::new()
+            .route(
+                "/api/v2/collections/{collection_id}/items/{item_id}",
+                patch(|Json(body): Json<Value>| async move { Json(body) }),
+            )
+            .route("/api/v2/collections/{collection_id}/assets", post(upload))
+            .route(
+                "/api/v2/assets/{asset_id}/content",
+                get(|| async {
+                    (
+                        [(header::CONTENT_TYPE, "application/octet-stream")],
+                        BINARY_CONTENT,
+                    )
+                }),
+            )
+            .route(
+                "/api/v2/busy",
+                get(|| async {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        [(header::RETRY_AFTER, "7")],
+                        Json(json!({"code": "capacity"})),
+                    )
+                }),
+            )
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&observations),
+                observe,
+            ));
+
+        let mut document: Value =
+            serde_json::from_str(include_str!("../fixtures/media-catalog.json"))
+                .expect("media catalog fixture");
+        document["servers"][0]["url"] = json!(format!("http://{address}/api/v2/"));
+        let spec = OpenApiSpec::from_json(&document.to_string()).expect("parse media API");
+        let executor = HttpExecutor {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("local HTTP client"),
+            base_url: spec.server_url().to_owned(),
+        };
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve media API");
+        });
+        Self {
+            tools: tools(),
+            spec,
+            executor,
+            observations,
+            server,
+        }
+    }
+
+    /// Resolve the configured name and run the public engine through to its MCP result.
+    pub async fn invoke(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        file_reads: FileReadPolicy<'_>,
+    ) -> CallToolResult {
+        let kind = self.tools.resolve(name).expect("configured media tool");
+        let effect = api::dispatch(kind, arguments.as_object(), &self.spec, &POLICY);
+        run(effect, &POLICY, &mut self.executor, file_reads)
+            .await
+            .expect("MCP result")
+    }
+
+    pub async fn requests(&self) -> Vec<ObservedRequest> {
+        self.observations.lock().await.clone()
+    }
+}
+
+impl Drop for Catalog {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}


### PR DESCRIPTION
The generic engine and runner had separate tests, but no unrelated OpenAPI specification had been exercised through real HTTP execution. Add a media-catalog integration fixture that uses the public generic metadata, dispatch, and runner interfaces with a test-only reqwest executor independent of Onshape's client and authentication.

Four tests cover alternate names for all four tools; JSON requests with a server path prefix, encoded path/query parameters, and a required header; local binary multipart uploads; binary downloads; HTTP 503 retry guidance; and denied file reads that send no HTTP request. The local server records incoming requests and echoes parsed JSON or multipart fields so assertions check the data received over HTTP.

Axum's multipart parser is enabled through a dev-only feature. Each test owns a loopback server with an ephemeral port, disables client proxy use, and stops the server on drop. The specification is embedded in the test binary for archive portability.

Validation:

- All 666 workspace tests pass (`cargo test --workspace --all-features --locked --offline`).
- Workspace Clippy with warnings denied and formatting checks pass.
- Verified the multipart parser and its new dependencies are absent from the normal application dependency tree.
