### PR TITLE
Move Onshape schema annotations into the host adapter

### DIFF
--- a/crates/onshape-mcp-core/src/tools.rs
+++ b/crates/onshape-mcp-core/src/tools.rs
@@ -3,11 +3,11 @@
 //! This module contains all tool metadata and pure business logic for tool execution.
 //! Uses rmcp types directly to avoid unnecessary type conversions.
 //!
-//! Onshape request validation and diagnostic interpretation live in the private
-//! `onshape` module. The `api` module handles `OpenAPI` search, explain,
+//! Onshape schema presentation, request validation, and diagnostics live in
+//! the private `onshape` module. The `api` module handles `OpenAPI` search, explain,
 //! schema lookup, and execution through its own effects and continuations.
-//! The Onshape adapter supplies validation and diagnostic policy and translates
-//! generic effects into the public dispatcher types used by the I/O layer.
+//! The Onshape adapter supplies this policy and translates generic effects into
+//! the public dispatcher types used by the I/O layer.
 //!
 //! ## Effect Pattern
 //!

--- a/crates/onshape-mcp-core/src/tools/api.rs
+++ b/crates/onshape-mcp-core/src/tools/api.rs
@@ -38,9 +38,9 @@ pub fn dispatch(
 ) -> Effect {
     match kind {
         ToolKind::Search => Effect::Done(search(arguments, spec)),
-        ToolKind::Explain => Effect::Done(explain(arguments, spec)),
+        ToolKind::Explain => Effect::Done(explain(arguments, spec, policy)),
         ToolKind::Call => call(arguments, spec, policy),
-        ToolKind::Schema => Effect::Done(schema(arguments, spec)),
+        ToolKind::Schema => Effect::Done(schema(arguments, spec, policy)),
     }
 }
 
@@ -72,12 +72,13 @@ pub(super) fn search(
 pub(super) fn explain(
     arguments: Option<&Map<String, Value>>,
     spec: &OpenApiSpec,
+    policy: &Policy,
 ) -> Result<CallToolResult, ErrorData> {
     let input: ApiExplainInput = match parse_arguments(arguments) {
         Ok(input) => input,
         Err(e) => return Ok(CallToolResult::error(vec![ContentBlock::text(e.message)])),
     };
-    let detail = match spec.explain(&input.endpoint) {
+    let mut detail = match spec.explain(&input.endpoint) {
         Ok(d) => d,
         Err(e) => {
             return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
@@ -86,6 +87,7 @@ pub(super) fn explain(
         }
     };
 
+    (policy.present_endpoint)(&mut detail, spec);
     let content = ContentBlock::json(&detail).map_err(|e| {
         ErrorData::new(
             ErrorCode::INTERNAL_ERROR,
@@ -223,12 +225,13 @@ pub(super) fn call(
 pub(super) fn schema(
     arguments: Option<&Map<String, Value>>,
     spec: &OpenApiSpec,
+    policy: &Policy,
 ) -> Result<CallToolResult, ErrorData> {
     let input: ApiSchemaInput = match parse_arguments(arguments) {
         Ok(input) => input,
         Err(e) => return Ok(CallToolResult::error(vec![ContentBlock::text(e.message)])),
     };
-    let detail = match spec.lookup_schema(&input.schema) {
+    let mut detail = match spec.lookup_schema(&input.schema) {
         Ok(d) => d,
         Err(e) => {
             return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
@@ -237,6 +240,7 @@ pub(super) fn schema(
         }
     };
 
+    (policy.present_schema)(&mut detail, spec);
     let content = ContentBlock::json(&detail).map_err(|e| {
         ErrorData::new(
             ErrorCode::INTERNAL_ERROR,
@@ -285,6 +289,8 @@ mod tests {
 
     fn policy(validate_body: BodyValidator) -> Policy {
         Policy {
+            present_endpoint: |_, _| {},
+            present_schema: |_, _| {},
             validate_body,
             validate_request: |_| Ok(()),
             append_error_details: |_, _| {},

--- a/crates/onshape-mcp-core/src/tools/api/execution.rs
+++ b/crates/onshape-mcp-core/src/tools/api/execution.rs
@@ -1,6 +1,6 @@
 //! Generic API effects, file injection, and response formatting.
 //!
-//! The host supplies synchronous validation and diagnostic policy on each call.
+//! The host supplies synchronous presentation, validation, and diagnostic policy.
 //! Effects and continuations contain only data, with no authentication or I/O.
 
 use std::collections::HashMap;
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use base64::Engine;
 use onshape_openapi::request::{ApiRequest, BinaryField, MultipartBody, RequestBody};
+use onshape_openapi::{EndpointDetail, OpenApiSpec, SchemaDetail};
 use rmcp::{
     ErrorData,
     model::{CallToolResult, ContentBlock, ErrorCode},
@@ -21,6 +22,10 @@ pub type BodyValidator = fn(&str, Option<&Value>, &[FileReference]) -> Result<()
 
 /// Synchronous host policy, supplied separately from plain-data continuations.
 pub struct Policy {
+    /// Customize endpoint details before serialization without changing the spec.
+    pub present_endpoint: fn(&mut EndpointDetail, &OpenApiSpec),
+    /// Customize component schema details before serialization without changing the spec.
+    pub present_schema: fn(&mut SchemaDetail, &OpenApiSpec),
     /// Validate the decoded body before generic file and request validation.
     pub validate_body: BodyValidator,
     /// Validate the final request after file contents have been injected.

--- a/crates/onshape-mcp-core/src/tools/onshape.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape.rs
@@ -1,9 +1,10 @@
-//! Onshape request validation and diagnostic interpretation for MCP tools.
+//! Onshape schema presentation, request validation, and diagnostics for MCP tools.
 //!
 //! This adapter supplies policy to generic API execution and translates its
 //! effects into the public Onshape dispatcher types. All helpers operate on data.
 
 mod metadata;
+mod schema;
 
 pub use metadata::api_tools;
 
@@ -14,8 +15,10 @@ use serde_json::{Map, Value};
 
 use super::{Continuation, FileReference, ToolEffect, api};
 
-/// Onshape policy for request preparation, file injection, and API errors.
+/// Onshape policy for schema presentation, request preparation, and API errors.
 pub const API_POLICY: api::Policy = api::Policy {
+    present_endpoint: schema::present_endpoint,
+    present_schema: schema::present_schema,
     validate_body: validate_call_body,
     validate_request: validate_injected_request,
     append_error_details: append_api_error_details,

--- a/crates/onshape-mcp-core/src/tools/onshape/schema.rs
+++ b/crates/onshape-mcp-core/src/tools/onshape/schema.rs
@@ -1,18 +1,33 @@
-//! Onshape schema presentation for the public compatibility API.
+//! Onshape schema presentation for MCP endpoint explanations and schema lookup.
 //!
 //! The annotation name is Onshape-specific; discriminator discovery belongs to
 //! the standard schema catalog. Keep these annotations out of parsed schemas.
 
 use serde_json::Value;
 
-use crate::schema::SchemaCatalog;
+use onshape_openapi::{EndpointDetail, OpenApiSpec, SchemaDetail};
+
+/// Annotate endpoint request and response schemas without mutating the catalog.
+pub(super) fn present_endpoint(detail: &mut EndpointDetail, spec: &OpenApiSpec) {
+    for schema in [&mut detail.request_body_schema, &mut detail.response_schema]
+        .into_iter()
+        .flatten()
+    {
+        *schema = annotate_schema_properties(schema, spec);
+    }
+}
+
+/// Annotate a component's merged properties without mutating the catalog.
+pub(super) fn present_schema(detail: &mut SchemaDetail, spec: &OpenApiSpec) {
+    detail.properties = annotate_discriminators(&detail.properties, spec);
+}
 
 /// Walk a schema's properties and annotate any `$ref` (or `items.$ref`)
 /// that points to a schema with a `discriminator.mapping` by adding an
 /// `x-bttype-options` array listing the valid btType values.
 ///
 /// Only examines one level of properties (does not recurse into subtypes).
-pub fn annotate_discriminators(schema: &Value, schemas: &SchemaCatalog) -> Value {
+fn annotate_discriminators(schema: &Value, spec: &OpenApiSpec) -> Value {
     let Some(props) = schema.as_object() else {
         return schema.clone();
     };
@@ -20,7 +35,7 @@ pub fn annotate_discriminators(schema: &Value, schemas: &SchemaCatalog) -> Value
     let mut annotated = props.clone();
 
     for (key, value) in props {
-        let annotated_value = annotate_single_property(value, schemas);
+        let annotated_value = annotate_single_property(value, spec);
         if annotated_value != *value {
             annotated.insert(key.clone(), annotated_value);
         }
@@ -31,10 +46,10 @@ pub fn annotate_discriminators(schema: &Value, schemas: &SchemaCatalog) -> Value
 
 /// Check a single property value for `$ref` or `items.$ref` pointing to
 /// a schema with a discriminator, and annotate it with `x-bttype-options`.
-fn annotate_single_property(value: &Value, schemas: &SchemaCatalog) -> Value {
+fn annotate_single_property(value: &Value, spec: &OpenApiSpec) -> Value {
     // Direct $ref
     if let Some(ref_str) = value.get("$ref").and_then(Value::as_str)
-        && let Some(options) = schemas.discriminator_options(ref_str)
+        && let Some(options) = spec.discriminator_options(ref_str)
     {
         let mut annotated = value.as_object().cloned().unwrap_or_default();
         annotated.insert("x-bttype-options".to_string(), Value::from(options));
@@ -44,7 +59,7 @@ fn annotate_single_property(value: &Value, schemas: &SchemaCatalog) -> Value {
     // items.$ref (for array properties)
     if let Some(items) = value.get("items")
         && let Some(ref_str) = items.get("$ref").and_then(Value::as_str)
-        && let Some(options) = schemas.discriminator_options(ref_str)
+        && let Some(options) = spec.discriminator_options(ref_str)
     {
         let mut annotated_items = items.as_object().cloned().unwrap_or_default();
         annotated_items.insert("x-bttype-options".to_string(), Value::from(options));
@@ -61,7 +76,7 @@ fn annotate_single_property(value: &Value, schemas: &SchemaCatalog) -> Value {
 /// If the schema has a `properties` object, walk it and annotate any `$ref`
 /// properties that point to discriminator schemas. Returns the schema with
 /// the annotated properties in place.
-pub fn annotate_schema_properties(schema: &Value, schemas: &SchemaCatalog) -> Value {
+fn annotate_schema_properties(schema: &Value, spec: &OpenApiSpec) -> Value {
     let mut result = schema.clone();
     let Some(obj) = result.as_object_mut() else {
         return result;
@@ -70,7 +85,7 @@ pub fn annotate_schema_properties(schema: &Value, schemas: &SchemaCatalog) -> Va
     if let Some(props) = obj.get("properties").cloned() {
         obj.insert(
             "properties".to_string(),
-            annotate_discriminators(&props, schemas),
+            annotate_discriminators(&props, spec),
         );
     }
 
@@ -82,7 +97,7 @@ pub fn annotate_schema_properties(schema: &Value, schemas: &SchemaCatalog) -> Va
             if let Some(item_obj) = item.as_object_mut() {
                 item_obj.insert(
                     "properties".to_string(),
-                    annotate_discriminators(&props, schemas),
+                    annotate_discriminators(&props, spec),
                 );
             }
         }

--- a/crates/onshape-mcp-core/tests/fixtures/onshape-schema-presentation.json
+++ b/crates/onshape-mcp-core/tests/fixtures/onshape-schema-presentation.json
@@ -1,0 +1,72 @@
+{
+  "boolean": {
+    "content": [
+      {
+        "text": "{\"operation_id\":\"booleanSchema\",\"method\":\"GET\",\"path\":\"/boolean\",\"description\":\"\",\"tags\":[],\"parameters\":[],\"has_request_body\":false,\"response_schema\":true,\"response_content_types\":[\"application/json\"]}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "composed": {
+    "content": [
+      {
+        "text": "{\"name\":\"Composed\",\"properties\":{\"empty\":{\"$ref\":\"#/components/schemas/Empty\"},\"external\":{\"$ref\":\"https://example.com/pet.json\"},\"label\":{\"type\":\"string\",\"x-example\":\"retained\"},\"missing\":{\"$ref\":\"#/components/schemas/Missing\"},\"nested\":{\"properties\":{\"pet\":{\"$ref\":\"#/components/schemas/Pet\"}},\"type\":\"object\"},\"pet\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"pets\":{\"items\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"type\":\"array\"},\"plain\":{\"$ref\":\"#/components/schemas/Plain\"},\"sourceAnnotation\":{\"type\":\"string\",\"x-bttype-options\":[\"source-value\"]}}}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "empty": {
+    "content": [
+      {
+        "text": "{\"operation_id\":\"empty\",\"method\":\"GET\",\"path\":\"/empty\",\"description\":\"\",\"tags\":[],\"parameters\":[],\"has_request_body\":false}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "emptyMapping": {
+    "content": [
+      {
+        "text": "{\"name\":\"Empty\",\"properties\":{},\"subtypes\":[],\"discriminator_property\":\"kind\"}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "explain": {
+    "content": [
+      {
+        "text": "{\"operation_id\":\"createPet\",\"method\":\"POST\",\"path\":\"/pets\",\"description\":\"\",\"tags\":[],\"parameters\":[],\"has_request_body\":true,\"request_body_schema\":{\"properties\":{\"empty\":{\"$ref\":\"#/components/schemas/Empty\"},\"external\":{\"$ref\":\"https://example.com/pet.json\"},\"label\":{\"type\":\"string\",\"x-example\":\"retained\"},\"missing\":{\"$ref\":\"#/components/schemas/Missing\"},\"nested\":{\"properties\":{\"pet\":{\"$ref\":\"#/components/schemas/Pet\"}},\"type\":\"object\"},\"pet\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"pets\":{\"items\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"type\":\"array\"},\"plain\":{\"$ref\":\"#/components/schemas/Plain\"},\"sourceAnnotation\":{\"type\":\"string\",\"x-bttype-options\":[\"source-value\"]}},\"type\":\"object\"},\"request_body_content_type\":\"application/json\",\"response_schema\":{\"allOf\":[{\"properties\":{\"empty\":{\"$ref\":\"#/components/schemas/Empty\"},\"external\":{\"$ref\":\"https://example.com/pet.json\"},\"label\":{\"type\":\"string\",\"x-example\":\"retained\"},\"missing\":{\"$ref\":\"#/components/schemas/Missing\"},\"nested\":{\"properties\":{\"pet\":{\"$ref\":\"#/components/schemas/Pet\"}},\"type\":\"object\"},\"pet\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"pets\":{\"items\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"type\":\"array\"},\"plain\":{\"$ref\":\"#/components/schemas/Plain\"},\"sourceAnnotation\":{\"type\":\"string\",\"x-bttype-options\":[\"source-value\"]}}},{\"description\":\"No properties\"},true]},\"response_content_types\":[\"application/json\"]}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "schema": {
+    "content": [
+      {
+        "text": "{\"name\":\"Envelope\",\"properties\":{\"empty\":{\"$ref\":\"#/components/schemas/Empty\"},\"external\":{\"$ref\":\"https://example.com/pet.json\"},\"label\":{\"type\":\"string\",\"x-example\":\"retained\"},\"missing\":{\"$ref\":\"#/components/schemas/Missing\"},\"nested\":{\"properties\":{\"pet\":{\"$ref\":\"#/components/schemas/Pet\"}},\"type\":\"object\"},\"pet\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"pets\":{\"items\":{\"$ref\":\"#/components/schemas/Pet\",\"x-bttype-options\":[\"cat\",\"dog\"]},\"type\":\"array\"},\"plain\":{\"$ref\":\"#/components/schemas/Plain\"},\"sourceAnnotation\":{\"type\":\"string\",\"x-bttype-options\":[\"source-value\"]}}}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  },
+  "subtypes": {
+    "content": [
+      {
+        "text": "{\"name\":\"Pet\",\"properties\":{\"kind\":{\"type\":\"string\"}},\"subtypes\":[\"cat\",\"dog\"],\"discriminator_property\":\"kind\"}",
+        "type": "text"
+      }
+    ],
+    "isError": false,
+    "resultType": "complete"
+  }
+}

--- a/crates/onshape-mcp-core/tests/schema_presentation.rs
+++ b/crates/onshape-mcp-core/tests/schema_presentation.rs
@@ -1,0 +1,288 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use onshape_mcp_core::{
+    ValidationState,
+    config::ResolvedAuth,
+    tools::api::{self, Effect, Policy, ToolKind},
+    tools::{self, ToolEffect},
+};
+use onshape_openapi::OpenApiSpec;
+use rmcp::model::CallToolResult;
+use serde_json::{Value, json};
+
+const NEUTRAL_POLICY: Policy = Policy {
+    present_endpoint: |_, _| {},
+    present_schema: |_, _| {},
+    validate_body: |_, _, _| Ok(()),
+    validate_request: |_| Ok(()),
+    append_error_details: |_, _| {},
+};
+
+fn specification() -> OpenApiSpec {
+    let pet_ref = json!({"$ref": "#/components/schemas/Pet"});
+    let properties = json!({
+        "pet": pet_ref,
+        "pets": {"type": "array", "items": pet_ref},
+        "label": {"type": "string", "x-example": "retained"},
+        "empty": {"$ref": "#/components/schemas/Empty"},
+        "plain": {"$ref": "#/components/schemas/Plain"},
+        "missing": {"$ref": "#/components/schemas/Missing"},
+        "external": {"$ref": "https://example.com/pet.json"},
+        "nested": {"type": "object", "properties": {"pet": pet_ref}},
+        "sourceAnnotation": {"type": "string", "x-bttype-options": ["source-value"]}
+    });
+    let media = |name: &str| {
+        json!({
+            "application/json": {"schema": {"$ref": format!("#/components/schemas/{name}")}}
+        })
+    };
+    OpenApiSpec::from_value(&json!({
+        "openapi": "3.0.1",
+        "info": {"title": "Pet API", "version": "1.0"},
+        "servers": [{"url": "https://example.com"}],
+        "paths": {
+            "/pets": {"post": {
+                "operationId": "createPet",
+                "requestBody": {"content": media("Envelope")},
+                "responses": {"200": {"description": "A pet", "content": media("Composed")}}
+            }},
+            "/empty": {"get": {
+                "operationId": "empty",
+                "responses": {"204": {"description": "No content"}}
+            }},
+            "/boolean": {"get": {
+                "operationId": "booleanSchema",
+                "responses": {"200": {"description": "Any value", "content": {
+                    "application/json": {"schema": true}
+                }}}
+            }}
+        },
+        "components": {"schemas": {
+            "Pet": {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}},
+                "discriminator": {
+                    "propertyName": "kind",
+                    "mapping": {
+                        "dog": "#/components/schemas/Dog",
+                        "cat": "#/components/schemas/Cat"
+                    }
+                }
+            },
+            "Cat": {"allOf": [pet_ref]},
+            "Dog": {"allOf": [pet_ref]},
+            "Empty": {"discriminator": {"propertyName": "kind", "mapping": {}}},
+            "Plain": {"type": "object"},
+            "Envelope": {"type": "object", "properties": properties},
+            "Composed": {"allOf": [
+                {"properties": properties},
+                {"description": "No properties"},
+                true
+            ]}
+        }}
+    }))
+    .expect("valid specification")
+}
+
+fn onshape_result(spec: &OpenApiSpec, name: &str, arguments: &Value) -> CallToolResult {
+    let ToolEffect::Done(result) = tools::call_tool(
+        name,
+        arguments.as_object(),
+        &ResolvedAuth::Basic,
+        &ValidationState::default(),
+        Some(spec),
+    ) else {
+        panic!("schema presentation must not produce I/O");
+    };
+    result.expect("tool result")
+}
+
+#[test]
+fn onshape_schema_presentation_matches_existing_output() {
+    let spec = specification();
+    let calls = [
+        (
+            "explain",
+            "onshape_api_explain",
+            json!({"endpoint": "createPet"}),
+        ),
+        ("empty", "onshape_api_explain", json!({"endpoint": "empty"})),
+        (
+            "boolean",
+            "onshape_api_explain",
+            json!({"endpoint": "booleanSchema"}),
+        ),
+        (
+            "schema",
+            "onshape_api_schema",
+            json!({"schema": "Envelope"}),
+        ),
+        (
+            "composed",
+            "onshape_api_schema",
+            json!({"schema": "Composed"}),
+        ),
+        ("subtypes", "onshape_api_schema", json!({"schema": "Pet"})),
+        (
+            "emptyMapping",
+            "onshape_api_schema",
+            json!({"schema": "Empty"}),
+        ),
+    ];
+    let actual: serde_json::Map<String, Value> = calls
+        .into_iter()
+        .map(|(key, name, args)| {
+            (
+                key.into(),
+                serde_json::to_value(onshape_result(&spec, name, &args)).expect("JSON result"),
+            )
+        })
+        .collect();
+    // Captured from the public Onshape dispatcher before moving annotations
+    // out of the parser. Compare the entire MCP result, including text encoding.
+    let expected: Value =
+        serde_json::from_str(include_str!("fixtures/onshape-schema-presentation.json"))
+            .expect("valid baseline snapshot");
+    assert_eq!(Value::Object(actual), expected);
+}
+
+fn generic_result(
+    spec: &OpenApiSpec,
+    kind: ToolKind,
+    arguments: &Value,
+    policy: &Policy,
+) -> CallToolResult {
+    let Effect::Done(result) = api::dispatch(kind, arguments.as_object(), spec, policy) else {
+        panic!("schema presentation must not produce I/O");
+    };
+    result.expect("tool result")
+}
+
+fn detail(result: &CallToolResult) -> Value {
+    assert_eq!(result.is_error, Some(false));
+    serde_json::from_str(&result.content[0].as_text().expect("text content").text)
+        .expect("JSON detail")
+}
+
+#[test]
+fn generic_tools_preserve_source_schemas_before_and_after_onshape_presentation() {
+    let spec = specification();
+    let endpoint = spec.explain("createPet").expect("endpoint");
+    let schema = spec.lookup_schema("Envelope").expect("schema");
+    let properties = &schema.properties;
+    assert_eq!(
+        properties["pet"],
+        json!({"$ref": "#/components/schemas/Pet"})
+    );
+    assert_eq!(properties["pets"]["items"], properties["pet"]);
+    assert_eq!(
+        properties["sourceAnnotation"]["x-bttype-options"],
+        json!(["source-value"])
+    );
+    assert_eq!(
+        endpoint.request_body_schema.as_ref().expect("request")["properties"],
+        *properties
+    );
+    assert_eq!(
+        endpoint.response_schema.as_ref().expect("response")["allOf"][0]["properties"],
+        *properties
+    );
+
+    for _ in 0..2 {
+        assert_eq!(
+            detail(&generic_result(
+                &spec,
+                ToolKind::Explain,
+                &json!({"endpoint": "createPet"}),
+                &NEUTRAL_POLICY
+            )),
+            serde_json::to_value(&endpoint).expect("endpoint JSON")
+        );
+        assert_eq!(
+            detail(&generic_result(
+                &spec,
+                ToolKind::Schema,
+                &json!({"schema": "Envelope"}),
+                &NEUTRAL_POLICY
+            )),
+            serde_json::to_value(&schema).expect("schema JSON")
+        );
+        let presented = detail(&onshape_result(
+            &spec,
+            "onshape_api_explain",
+            &json!({"endpoint": "createPet"}),
+        ));
+        assert_eq!(
+            presented["request_body_schema"]["properties"]["pet"]["x-bttype-options"],
+            json!(["cat", "dog"])
+        );
+        let presented = detail(&onshape_result(
+            &spec,
+            "onshape_api_schema",
+            &json!({"schema": "Envelope"}),
+        ));
+        assert_eq!(
+            presented["properties"]["pets"]["items"]["x-bttype-options"],
+            json!(["cat", "dog"])
+        );
+    }
+}
+
+#[test]
+fn alternate_host_can_present_both_detail_types() {
+    let spec = specification();
+    let policy = Policy {
+        present_endpoint: |detail, spec| {
+            assert!(spec.lookup_schema("Pet").is_ok());
+            detail.description = "Host endpoint guidance".into();
+        },
+        present_schema: |detail, spec| {
+            assert!(spec.explain("createPet").is_ok());
+            detail.description = Some("Host schema guidance".into());
+        },
+        ..NEUTRAL_POLICY
+    };
+    let endpoint = detail(&generic_result(
+        &spec,
+        ToolKind::Explain,
+        &json!({"endpoint": "createPet"}),
+        &policy,
+    ));
+    assert_eq!(endpoint["description"], "Host endpoint guidance");
+    let schema = detail(&generic_result(
+        &spec,
+        ToolKind::Schema,
+        &json!({"schema": "Envelope"}),
+        &policy,
+    ));
+    assert_eq!(schema["description"], "Host schema guidance");
+    assert_eq!(
+        endpoint["request_body_schema"]["properties"],
+        schema["properties"]
+    );
+    assert_eq!(
+        schema["properties"]["pet"],
+        json!({"$ref": "#/components/schemas/Pet"})
+    );
+}
+
+#[test]
+fn invalid_arguments_and_missing_entries_skip_presentation() {
+    let spec = specification();
+    let policy = Policy {
+        present_endpoint: |_, _| panic!("invalid explain must skip presentation"),
+        present_schema: |_, _| panic!("invalid lookup must skip presentation"),
+        ..NEUTRAL_POLICY
+    };
+    for (kind, args) in [
+        (ToolKind::Explain, json!({})),
+        (ToolKind::Explain, json!({"endpoint": "missing"})),
+        (ToolKind::Schema, json!({})),
+        (ToolKind::Schema, json!({"schema": "Missing"})),
+    ] {
+        assert_eq!(
+            generic_result(&spec, kind, &args, &policy).is_error,
+            Some(true)
+        );
+    }
+}

--- a/crates/onshape-mcp-io/src/api/tests.rs
+++ b/crates/onshape-mcp-io/src/api/tests.rs
@@ -9,6 +9,8 @@ use serde_json::{Value, json};
 use super::*;
 
 const POLICY: Policy = Policy {
+    present_endpoint: |_, _| {},
+    present_schema: |_, _| {},
     validate_body: |_, _, _| Ok(()),
     validate_request: |_| Ok(()),
     append_error_details: |_, _| {},

--- a/crates/onshape-mcp-io/tests/support/media_catalog.rs
+++ b/crates/onshape-mcp-io/tests/support/media_catalog.rs
@@ -25,6 +25,8 @@ pub const BINARY_CONTENT: &[u8] = &[0, 255, 10, 13, 128];
 pub const TOOL_NAMES: [&str; 4] = ["media.find", "media.describe", "media.send", "media.type"];
 
 const POLICY: Policy = Policy {
+    present_endpoint: |_, _| {},
+    present_schema: |_, _| {},
     validate_body: |_, _, _| Ok(()),
     validate_request: |_| Ok(()),
     append_error_details: |_, _| {},

--- a/crates/onshape-openapi/src/lib.rs
+++ b/crates/onshape-openapi/src/lib.rs
@@ -1,15 +1,13 @@
 //! `OpenAPI` spec parsing, searching, and request building.
 //!
-//! This crate provides pure (sans-IO) operations over an Onshape `OpenAPI` specification.
+//! This crate provides pure (sans-IO) operations over an `OpenAPI` specification.
 //! The spec JSON content is provided externally; this crate never performs I/O.
 //!
 //! Standard component schema inspection lives in the internal `schema` module.
-//! The public API adds Onshape presentation through the `onshape` module when
-//! returning explanations; parsed schemas retain their original metadata.
+//! Explanations retain source schema metadata without adding host annotations.
 //! The [`request`] module owns API-neutral request data; applications adapt it
 //! to their HTTP executor at the I/O boundary.
 
-mod onshape;
 pub mod request;
 mod schema;
 
@@ -405,6 +403,7 @@ impl OpenApiSpec {
     }
 
     /// Get full details for a specific endpoint by operation ID.
+    /// Schema metadata is returned without host-specific presentation annotations.
     ///
     /// # Errors
     ///
@@ -441,15 +440,9 @@ impl OpenApiSpec {
                 })
                 .collect(),
             has_request_body: ep.has_request_body,
-            request_body_schema: ep
-                .request_body_schema
-                .as_ref()
-                .map(|schema| onshape::annotate_schema_properties(schema, &self.schemas)),
+            request_body_schema: ep.request_body_schema.clone(),
             request_body_content_type: ep.request_body_content_type.clone(),
-            response_schema: ep
-                .response_schema
-                .as_ref()
-                .map(|schema| onshape::annotate_schema_properties(schema, &self.schemas)),
+            response_schema: ep.response_schema.clone(),
             response_content_types: ep.response_content_types.clone(),
         })
     }
@@ -650,16 +643,23 @@ impl OpenApiSpec {
     /// Look up a component schema by name and return its detail.
     ///
     /// Merges parent properties (from `allOf.$ref`) into a flat `properties`
-    /// object, annotates polymorphic `$ref` properties with `x-bttype-options`,
-    /// and includes the discriminator subtypes if the schema is polymorphic.
+    /// object and includes the discriminator subtypes if the schema is polymorphic.
+    /// Source metadata is retained without adding host presentation annotations.
     ///
     /// # Errors
     ///
     /// Returns an error if the schema name is not found in the spec's components.
     pub fn lookup_schema(&self, name: &str) -> Result<SchemaDetail, OpenApiError> {
-        let mut detail = self.schemas.lookup(name)?;
-        detail.properties = onshape::annotate_discriminators(&detail.properties, &self.schemas);
-        Ok(detail)
+        self.schemas.lookup(name)
+    }
+
+    /// Return discriminator mapping keys for a local component schema reference.
+    ///
+    /// Returns `None` for unresolved or non-component references and for absent
+    /// or empty mappings. Schema lookup retains explicitly empty subtype lists.
+    #[must_use]
+    pub fn discriminator_options(&self, reference: &str) -> Option<Vec<String>> {
+        self.schemas.discriminator_options(reference)
     }
 
     // ========================================================================
@@ -952,14 +952,15 @@ const fn json_type_name(value: &Value) -> &'static str {
 mod tests {
     use super::*;
 
-    /// Check that Onshape presentation leaves standard schema metadata intact.
+    /// Public explanations preserve source metadata without adding annotations.
     #[test]
-    fn explanations_add_annotations_without_changing_standard_schema_data() {
+    fn explanations_preserve_standard_schema_data_without_annotations() {
         let pet_ref = serde_json::json!({ "$ref": "#/components/schemas/Pet" });
         let properties = serde_json::json!({
             "pet": pet_ref,
             "pets": { "type": "array", "items": pet_ref },
-            "label": { "type": "string", "x-example": "retained" }
+            "label": { "type": "string", "x-example": "retained" },
+            "sourceAnnotation": { "type": "string", "x-bttype-options": ["retained"] }
         });
         let envelope = serde_json::json!({ "allOf": [{ "properties": properties }] });
         let media = serde_json::json!({
@@ -995,27 +996,22 @@ mod tests {
         }))
         .expect("should parse");
 
-        let pet = spec.schemas.lookup("Pet").expect("should find pet");
+        let pet = spec.lookup_schema("Pet").expect("should find pet");
         assert_eq!(pet.discriminator_property.as_deref(), Some("kind"));
         assert_eq!(pet.subtypes, Some(vec!["cat".to_string()]));
 
-        let mut annotated = envelope.clone();
-        annotated["allOf"][0]["properties"]["pet"]["x-bttype-options"] = serde_json::json!(["cat"]);
-        annotated["allOf"][0]["properties"]["pets"]["items"]["x-bttype-options"] =
-            serde_json::json!(["cat"]);
-
         let detail = spec.explain("createPet").expect("should find endpoint");
-        assert_eq!(detail.request_body_schema.as_ref(), Some(&annotated));
-        assert_eq!(detail.response_schema.as_ref(), Some(&annotated));
+        assert_eq!(detail.request_body_schema.as_ref(), Some(&envelope));
+        assert_eq!(detail.response_schema.as_ref(), Some(&envelope));
         assert_eq!(
             spec.lookup_schema("Envelope")
                 .expect("should find schema")
                 .properties,
-            annotated["allOf"][0]["properties"]
+            properties
         );
 
         // The standard catalog and parsed endpoint still contain only source
-        // metadata after the public API has produced annotated explanations.
+        // metadata after the public API has produced explanations.
         assert_eq!(
             spec.schemas
                 .lookup("Envelope")
@@ -2055,11 +2051,11 @@ mod tests {
     }
 
     // ====================================================================
-    // Discriminator Annotation Tests
+    // Discriminator Metadata Tests
     // ====================================================================
 
     #[test]
-    fn explain_annotates_discriminator_refs_in_request_body() {
+    fn explain_preserves_discriminator_refs_in_request_body() {
         let spec = OpenApiSpec::from_json(test_spec_json()).expect("should parse");
         let detail = spec.explain("addFeature").expect("should find");
 
@@ -2070,37 +2066,43 @@ mod tests {
 
         // The "feature" property refs BTMFeature-134 which has a discriminator.
         let feature = props.get("feature").expect("should have feature property");
-        let options = feature
-            .get("x-bttype-options")
-            .expect("should have x-bttype-options annotation");
-        let options_arr = options.as_array().expect("should be an array");
-        assert!(options_arr.len() >= 2);
-        assert!(options_arr.contains(&Value::String("BTMSketch-151".to_string())));
-        assert!(options_arr.contains(&Value::String("BTMFeatureInvalid-1031".to_string())));
+        assert_eq!(
+            feature,
+            &serde_json::json!({"$ref": "#/components/schemas/BTMFeature-134"})
+        );
+        let options = spec
+            .discriminator_options("#/components/schemas/BTMFeature-134")
+            .expect("standard discriminator options remain available");
+        assert_eq!(options, ["BTMFeatureInvalid-1031", "BTMSketch-151"]);
     }
 
     #[test]
-    fn explain_annotates_discriminator_refs_in_array_items() {
+    fn lookup_schema_preserves_discriminator_refs_in_array_items() {
         let spec = OpenApiSpec::from_json(test_spec_json()).expect("should parse");
 
         // BTMFeature-134 has "parameters" which is an array of BTMParameter-1 refs.
-        // When addFeature is explained, the resolved BTFeatureDefinitionCall-1406
-        // should show annotations on the feature ref... but BTMFeature-134's own
-        // properties aren't resolved in the explain output (only one level of ref
-        // resolution). So let's use lookup_schema to check array items annotation.
+        // Lookup retains the reference without adding presentation annotations.
         let detail = spec
             .lookup_schema("BTMFeature-134")
             .expect("should find schema");
         let props = detail.properties.as_object().expect("should be object");
         let params = props.get("parameters").expect("should have parameters");
         let items = params.get("items").expect("should have items");
-        let options = items
-            .get("x-bttype-options")
-            .expect("items should have x-bttype-options");
-        let options_arr = options.as_array().expect("should be an array");
-        assert!(options_arr.contains(&Value::String("BTMParameterEnum-145".to_string())));
-        assert!(options_arr.contains(&Value::String("BTMParameterQuantity-147".to_string())));
-        assert!(options_arr.contains(&Value::String("BTMParameterString-149".to_string())));
+        assert_eq!(
+            items,
+            &serde_json::json!({"$ref": "#/components/schemas/BTMParameter-1"})
+        );
+        let options = spec
+            .discriminator_options("#/components/schemas/BTMParameter-1")
+            .expect("standard discriminator options remain available");
+        assert_eq!(
+            options,
+            [
+                "BTMParameterEnum-145",
+                "BTMParameterQuantity-147",
+                "BTMParameterString-149"
+            ]
+        );
     }
 
     #[test]
@@ -2201,11 +2203,11 @@ mod tests {
         assert!(props.contains_key("feature"));
         assert!(props.contains_key("libraryVersion"));
 
-        // The "feature" property should be annotated with x-bttype-options
+        // The "feature" property retains its source reference.
         let feature = props.get("feature").expect("should have feature");
-        assert!(
-            feature.get("x-bttype-options").is_some(),
-            "feature ref should be annotated with discriminator options"
+        assert_eq!(
+            feature,
+            &serde_json::json!({"$ref": "#/components/schemas/BTMFeature-134"})
         );
     }
 

--- a/docs/src/project/architecture.md
+++ b/docs/src/project/architecture.md
@@ -33,6 +33,12 @@ Onshape's executor handles credentials, token refresh, and validation updates;
 its dispatcher retains auth and screenshot continuations. Existing public
 Onshape effects are adapted to the generic runner at the I/O boundary.
 
+`onshape-openapi` returns schema details with source metadata and standard
+discriminator information. It does not add presentation annotations. Generic
+explain and schema tools apply the host's presentation callbacks before
+serialization; the Onshape adapter adds `x-bttype-options` through those callbacks
+without changing the parsed specification.
+
 See [Data Flow](data-flow.md) for sequence diagrams showing how requests,
 authentication, and token refresh flow through each operating mode.
 


### PR DESCRIPTION
Generic endpoint explanations and schema lookups still added Onshape's `x-bttype-options` annotations, even when invoked by another host. Make `OpenApiSpec::explain()` and `lookup_schema()` return source schema metadata, and move annotation into the Onshape MCP adapter.

Add synchronous endpoint and schema presentation callbacks to the existing host policy. The adapter uses a public, neutral discriminator-options accessor; generic hosts supply no-op callbacks. Direct parser callers now receive neutral results, while `onshape_api_explain` and `onshape_api_schema` retain their existing output. Source-provided extension fields are preserved.

Capture the complete Onshape MCP results before the refactor and compare against that fixture afterward. Regression coverage includes direct and array references, request and response schemas, `allOf`, empty mappings, unresolved references, and source annotations. Additional tests verify neutral results before and after Onshape presentation, alternate host callbacks, and presentation being skipped for invalid arguments or missing entries.

Validation:

- `cargo nextest run --workspace --all-features --locked --offline` — 669 passed.
- `cargo clippy --workspace --all-targets --all-features --locked --offline -- -D warnings` — passed.
- Focused parser/core tests and doc tests — passed.
